### PR TITLE
Ender 3/5/5-Pro Preheat ABS Config Update

### DIFF
--- a/config/examples/Creality/Ender-3/Configuration.h
+++ b/config/examples/Creality/Ender-3/Configuration.h
@@ -1485,7 +1485,7 @@
 
 #define PREHEAT_2_LABEL       "ABS"
 #define PREHEAT_2_TEMP_HOTEND 240
-#define PREHEAT_2_TEMP_BED      0
+#define PREHEAT_2_TEMP_BED     70
 #define PREHEAT_2_FAN_SPEED   255 // Value from 0 to 255
 
 /**

--- a/config/examples/Creality/Ender-5 Pro/Configuration.h
+++ b/config/examples/Creality/Ender-5 Pro/Configuration.h
@@ -1479,7 +1479,7 @@
 
 #define PREHEAT_2_LABEL       "ABS"
 #define PREHEAT_2_TEMP_HOTEND 240
-#define PREHEAT_2_TEMP_BED      0
+#define PREHEAT_2_TEMP_BED     70
 #define PREHEAT_2_FAN_SPEED   255 // Value from 0 to 255
 
 /**

--- a/config/examples/Creality/Ender-5/Configuration.h
+++ b/config/examples/Creality/Ender-5/Configuration.h
@@ -1485,7 +1485,7 @@
 
 #define PREHEAT_2_LABEL       "ABS"
 #define PREHEAT_2_TEMP_HOTEND 240
-#define PREHEAT_2_TEMP_BED      0
+#define PREHEAT_2_TEMP_BED     70
 #define PREHEAT_2_FAN_SPEED   255 // Value from 0 to 255
 
 /**


### PR DESCRIPTION
Re-doing the PR based on @thinkyhead's request in #19 . 

"Preheat bed temp for ABS on Ender 3, Ender 5, and Ender 5 Pro "configuration.h" was originally set to 0C. Changed to 70C to reflect the source code from Creality: https://www.creality.com/download/source-code_c0001"