### PR TITLE
Improve BigTreeTech BTT002 config

### DIFF
--- a/config/examples/BigTreeTech/BTT002 - Prusa MK3S - TMC2209/Configuration_adv.h
+++ b/config/examples/BigTreeTech/BTT002 - Prusa MK3S - TMC2209/Configuration_adv.h
@@ -2905,7 +2905,7 @@
  *
  * Execute certain G-code commands immediately after power-on.
  */
-//#define STARTUP_COMMANDS "M17 Z"
+#define STARTUP_COMMANDS "M17 Z"
 
 /**
  * G-code Macros

--- a/config/examples/BigTreeTech/BTT002 - Prusa MK3S - TMC2209/Configuration_adv.h
+++ b/config/examples/BigTreeTech/BTT002 - Prusa MK3S - TMC2209/Configuration_adv.h
@@ -2922,27 +2922,15 @@
 /**
  * User-defined menu items that execute custom GCode
  */
-//#define CUSTOM_USER_MENUS
+#define CUSTOM_USER_MENUS
 #if ENABLED(CUSTOM_USER_MENUS)
   //#define CUSTOM_USER_MENU_TITLE "Custom Commands"
-  #define USER_SCRIPT_DONE "M117 User Script Done"
+  //#define USER_SCRIPT_DONE "M117 User Script Done"
   #define USER_SCRIPT_AUDIBLE_FEEDBACK
   //#define USER_SCRIPT_RETURN  // Return to status screen after a script
 
-  #define USER_DESC_1 "Home & UBL Info"
-  #define USER_GCODE_1 "G28\nG29 W"
-
-  #define USER_DESC_2 "Preheat for " PREHEAT_1_LABEL
-  #define USER_GCODE_2 "M140 S" STRINGIFY(PREHEAT_1_TEMP_BED) "\nM104 S" STRINGIFY(PREHEAT_1_TEMP_HOTEND)
-
-  #define USER_DESC_3 "Preheat for " PREHEAT_2_LABEL
-  #define USER_GCODE_3 "M140 S" STRINGIFY(PREHEAT_2_TEMP_BED) "\nM104 S" STRINGIFY(PREHEAT_2_TEMP_HOTEND)
-
-  #define USER_DESC_4 "Heat Bed/Home/Level"
-  #define USER_GCODE_4 "M140 S" STRINGIFY(PREHEAT_2_TEMP_BED) "\nG28\nG29"
-
-  #define USER_DESC_5 "Home & Info"
-  #define USER_GCODE_5 "G28\nM503"
+  #define USER_DESC_1 "Level Gantry"
+  #define USER_GCODE_1 "M117 " USER_DESC_1 "\nG28\nG0 Z" STRINGIFY(Z_MAX_POS) "\nM211 S0\nG28 R10 F240\nM211 S1\nG28 Z\nM0 Gantry Leveled"
 #endif
 
 /**

--- a/config/examples/BigTreeTech/BTT002 - Prusa MK3S - TMC2209/README.md
+++ b/config/examples/BigTreeTech/BTT002 - Prusa MK3S - TMC2209/README.md
@@ -6,9 +6,6 @@
 - 4 x TMC2209s
 
 ## Upgrade Notes
-* Cut or desolder the Z & E driver DIAG pins or they will interfere with PINDA & filament runout detection.
+* ⚠️ Cut or desolder the Z & E driver DIAG pins or they will interfere with PINDA & filament runout detection. ⚠️
 * Set the jumpers under your drivers to "TMC2208-UART MODE":
 ![image](https://user-images.githubusercontent.com/13375512/74117621-24415000-4b6d-11ea-8811-f867e187ea0c.png)
-
-## Known Issues
-* Save/send `M500` twice or `EEPROM_SETTINGS` won't stick on reboot.


### PR DESCRIPTION
### Description

Improve BigTreeTech BTT002 config:
- Enable Z steppers on boot
- Add "Level Gantry" custom user script which mimics stock Prusa firmware by running the X axis all the way to the top of travel + 10mm.
- Readme updates: Remove "Known Issues" section since saving to EEPROM works correctly now and also added warning emojis around the DIAG pin removal line to call attention to it.