### PR TITLE
Revert BTT002 Custom User Menus

### DIFF
--- a/config/examples/BigTreeTech/BTT002 - Prusa MK3S - TMC2209/Configuration_adv.h
+++ b/config/examples/BigTreeTech/BTT002 - Prusa MK3S - TMC2209/Configuration_adv.h
@@ -2949,15 +2949,27 @@
 /**
  * User-defined menu items that execute custom GCode
  */
-#define CUSTOM_USER_MENUS
+//#define CUSTOM_USER_MENUS
 #if ENABLED(CUSTOM_USER_MENUS)
   //#define CUSTOM_USER_MENU_TITLE "Custom Commands"
-  //#define USER_SCRIPT_DONE "M117 User Script Done"
+  #define USER_SCRIPT_DONE "M117 User Script Done"
   #define USER_SCRIPT_AUDIBLE_FEEDBACK
   //#define USER_SCRIPT_RETURN  // Return to status screen after a script
 
-  #define USER_DESC_1 "Level Gantry"
-  #define USER_GCODE_1 "M117 " USER_DESC_1 "\nG28\nG0 Z" STRINGIFY(Z_MAX_POS) "\nM211 S0\nG28 R10 F240\nM211 S1\nG28 Z\nM0 Gantry Leveled"
+  #define USER_DESC_1 "Home & UBL Info"
+  #define USER_GCODE_1 "G28\nG29 W"
+
+  #define USER_DESC_2 "Preheat for " PREHEAT_1_LABEL
+  #define USER_GCODE_2 "M140 S" STRINGIFY(PREHEAT_1_TEMP_BED) "\nM104 S" STRINGIFY(PREHEAT_1_TEMP_HOTEND)
+
+  #define USER_DESC_3 "Preheat for " PREHEAT_2_LABEL
+  #define USER_GCODE_3 "M140 S" STRINGIFY(PREHEAT_2_TEMP_BED) "\nM104 S" STRINGIFY(PREHEAT_2_TEMP_HOTEND)
+
+  #define USER_DESC_4 "Heat Bed/Home/Level"
+  #define USER_GCODE_4 "M140 S" STRINGIFY(PREHEAT_2_TEMP_BED) "\nG28\nG29"
+
+  #define USER_DESC_5 "Home & Info"
+  #define USER_GCODE_5 "G28\nM503"
 #endif
 
 /**


### PR DESCRIPTION
My clever x gantry leveling script doesn't seem to work most of the time and I can't figure out why.

It seems to work more often than not if you disable the filament runout sensor, but I don't have time to track down _why in the world_ that would affect the script.

Maybe it needs some more `M400`s? Maybe `G28 R10` respects `Z_MAX_POS` whenever it wants despite disabling software endstops? Maybe an `STM32` bug?

I have no idea, so it'll just be reverted for now.