### PR TITLE
Fix Tornado bed width

### DIFF
--- a/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration.h
+++ b/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration.h
@@ -1107,7 +1107,7 @@
 // @section machine
 
 // The size of the print bed
-#define X_BED_SIZE 320
+#define X_BED_SIZE 300
 #define Y_BED_SIZE 300
 
 // Travel limits (mm) after homing, corresponding to endstop positions.

--- a/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration.h
+++ b/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration.h
@@ -1107,7 +1107,7 @@
 // @section machine
 
 // The size of the print bed
-#define X_BED_SIZE 300
+#define X_BED_SIZE 310
 #define Y_BED_SIZE 300
 
 // Travel limits (mm) after homing, corresponding to endstop positions.

--- a/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration.h
+++ b/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration.h
@@ -1107,7 +1107,7 @@
 // @section machine
 
 // The size of the print bed
-#define X_BED_SIZE 320
+#define X_BED_SIZE 310
 #define Y_BED_SIZE 300
 
 // Travel limits (mm) after homing, corresponding to endstop positions.


### PR DESCRIPTION
Point 3, 6 and 9 are outside of the bed because of wrong bed size set.
Tevo Tornado's printing range is 300x300x400.