### PR TITLE
Disable Hybrid Threshold on SKR Mini E3 configs

### DIFF
--- a/config/examples/BigTreeTech/SKR Mini E3 1.0/Configuration_adv.h
+++ b/config/examples/BigTreeTech/SKR Mini E3 1.0/Configuration_adv.h
@@ -2342,7 +2342,7 @@
    * STEALTHCHOP_(XY|Z|E) must be enabled to use HYBRID_THRESHOLD.
    * M913 X/Y/Z/E to live tune the setting
    */
-  #define HYBRID_THRESHOLD
+  //#define HYBRID_THRESHOLD
 
   #define X_HYBRID_THRESHOLD     100  // [mm/s]
   #define X2_HYBRID_THRESHOLD    100

--- a/config/examples/BigTreeTech/SKR Mini E3 1.2/Configuration_adv.h
+++ b/config/examples/BigTreeTech/SKR Mini E3 1.2/Configuration_adv.h
@@ -2342,7 +2342,7 @@
    * STEALTHCHOP_(XY|Z|E) must be enabled to use HYBRID_THRESHOLD.
    * M913 X/Y/Z/E to live tune the setting
    */
-  #define HYBRID_THRESHOLD
+  //#define HYBRID_THRESHOLD
 
   #define X_HYBRID_THRESHOLD     100  // [mm/s]
   #define X2_HYBRID_THRESHOLD    100


### PR DESCRIPTION
## Description

Disable `HYBRID_THRESHOLD` on SKR Mini E3 configs because users aren't used to the noise when TMCs kick over to SpreadCycle.

This should be fine for a stock Ender-3, but users can always enable & tune to their liking if they print at higher speeds, go direct drive, install a glass bed, etc.

See comments in https://github.com/MarlinFirmware/Configurations/pull/101 for more info.