### PR TITLE
Enable SPEAKER on BTT002

### DIFF
--- a/config/examples/BigTreeTech/BTT002 - Prusa MK3S - TMC2209/Configuration.h
+++ b/config/examples/BigTreeTech/BTT002 - Prusa MK3S - TMC2209/Configuration.h
@@ -1745,7 +1745,7 @@
 // If you have a speaker that can produce tones, enable it here.
 // By default Marlin assumes you have a buzzer with a fixed frequency.
 //
-//#define SPEAKER
+#define SPEAKER
 
 //
 // The duration and frequency for the UI feedback sound.


### PR DESCRIPTION
### Requirements

Prusa MK3S with a BTT002

### Description

With tones working correctly after shuffling BTT002 timers, it's now safe to enable `SPEAKER` in the BTT002 config.

### Benefits

Those sweet `M300` tones now work correctly on a BTT002. 🎶

### Related Issues

~~https://github.com/MarlinFirmware/Marlin/pull/18011 needs to be merged first.~~ Merged!