### PR TITLE
Use PROBING_MARGIN instead of MIN_PROBE_EDGE

### DIFF
--- a/config/examples/BigTreeTech/SKR Mini E3 2.0/Configuration.h
+++ b/config/examples/BigTreeTech/SKR Mini E3 2.0/Configuration.h
@@ -969,7 +969,7 @@
 
 // Most probes should stay away from the edges of the bed, but
 // with NOZZLE_AS_PROBE this can be negative for a wider probing area.
-#define MIN_PROBE_EDGE 10
+#define PROBING_MARGIN 10
 
 // X and Y axis travel speed (mm/m) between probes
 #define XY_PROBE_SPEED 8000

--- a/config/examples/JGAurora/A3/Configuration.h
+++ b/config/examples/JGAurora/A3/Configuration.h
@@ -976,7 +976,7 @@
 
 // Most probes should stay away from the edges of the bed, but
 // with NOZZLE_AS_PROBE this can be negative for a wider probing area.
-#define MIN_PROBE_EDGE 10
+#define PROBING_MARGIN 10
 
 // X and Y axis travel speed (mm/m) between probes
 #define XY_PROBE_SPEED 8000


### PR DESCRIPTION
### Description

Use `PROBING_MARGIN` instead of `MIN_PROBE_EDGE`.

### Benefits

SKR Mini E3 V2 & JGAurora A3 configs compile without errors.

### Related Issues

https://github.com/MarlinFirmware/Marlin/pull/18140