### PR TITLE
Fix Geeetech/G2S mirrored feeder

### DIFF
--- a/config/examples/delta/Geeetech/G2S/Configuration.h
+++ b/config/examples/delta/Geeetech/G2S/Configuration.h
@@ -1187,8 +1187,7 @@
 
 // For direct drive extruder v9 set to true, for geared extruder set to false.
 #define INVERT_E0_DIR true
-// Geeetech G2S usually comes with a "mirrored" feeder, so the secondary extrudes has to run in the opposite direction
-#define INVERT_E1_DIR false
+#define INVERT_E1_DIR false  // Geeetech G2S usually comes with a "mirrored" feeder running in the opposite direction
 #define INVERT_E2_DIR true
 #define INVERT_E3_DIR true
 #define INVERT_E4_DIR true

--- a/config/examples/delta/Geeetech/G2S/Configuration.h
+++ b/config/examples/delta/Geeetech/G2S/Configuration.h
@@ -1187,7 +1187,8 @@
 
 // For direct drive extruder v9 set to true, for geared extruder set to false.
 #define INVERT_E0_DIR true
-#define INVERT_E1_DIR true
+// Geeetech G2S usually comes with a "mirrored" feeder, so the secondary extrudes has to run in the opposite direction
+#define INVERT_E1_DIR false
 #define INVERT_E2_DIR true
 #define INVERT_E3_DIR true
 #define INVERT_E4_DIR true


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Geeetech G2S usually comes with a "mirrored" feeder, so the secondary extrudes has to run in the opposite direction.

### Benefits

Without this change the secondary extruder won'Ät extrude since the gear acually pulls out the filament.

