### PR TITLE
Modified wrong feed rates

### DIFF
--- a/config/examples/Creality/Ender-5_Plus/Configuration.h
+++ b/config/examples/Creality/Ender-5_Plus/Configuration.h
@@ -744,7 +744,7 @@
  * Override with M203
  *                                      X, Y, Z, E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_FEEDRATE          { 8000, 8000, 15, 15000 }
+#define DEFAULT_MAX_FEEDRATE          { 800, 800, 15, 1500 }
 
 //#define LIMITED_MAX_FR_EDITING        // Limit edit via M203 or LCD to DEFAULT_MAX_FEEDRATE * 2
 #if ENABLED(LIMITED_MAX_FR_EDITING)


### PR DESCRIPTION
### Description
Wrongly assumed assumed `mm/minute` instead of `mm/second` when adjusting this values.

### Benefits
Users with the respective printer configuration will benefit of the more realistic (much lower) maximum feed rate.
