### PR TITLE
Add X/Y/Z_HOME_BUMP_MM

### DIFF
--- a/config/examples/Creality/Ender-3 Pro/Configuration.h
+++ b/config/examples/Creality/Ender-3 Pro/Configuration.h
@@ -628,7 +628,11 @@
 //===========================================================================
 
 // @section homing
-
+// Homing hits each endstop, retracts by these distances, then does a slower bump.
+#define X_HOME_BUMP_MM 5
+#define Y_HOME_BUMP_MM 5
+#define Z_HOME_BUMP_MM 2
+#define HOMING_BUMP_DIVISOR { 2, 2, 4 }  // Re-Bump Speed Divisor (Divides the Homing Feedrate)   
 // Specify here all the endstop connectors that are connected to any endstop or probe.
 // Almost all printers will be using one per axis. Probes will use one or more of the
 // extra connectors. Leave undefined any used for non-endstop and non-probe purposes.


### PR DESCRIPTION
### Description

Added definitions for X_HOME_BUMP_MM, Y_HOME_BUMP_MM, and Z_HOME_BUMP_MM, as well as HOMING_BUMP_DIVISOR to fix issues when using the examples in a Marlin build.

### Benefits

Fixes compatibility issues when using the Ender 3 Pro example profile with Marlin by adding missing values.

### Related Issues

#165 Ender 3 Pro - X Y and Z Home Bumps not Defined