### PR TITLE
Automatically enable SDCARD_READONLY for Ender-3 and Ender-3-Pro

### DIFF
--- a/config/examples/Creality/Ender-3 Pro/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Pro/Configuration_adv.h
@@ -1118,7 +1118,7 @@
   // Enable this option and set to HIGH if your SD cards are incorrectly detected.
   //#define SD_DETECT_STATE HIGH
 
-  #if DISABLED(POWER_LOSS_RECOVERY)
+  #if DISABLED(POWER_LOSS_RECOVERY) && DISABLED(BINARY_FILE_TRANSFER) && DISABLED(SDCARD_EEPROM_EMULATION)
     #define SDCARD_READONLY                 // Read-only SD card (to save over 2K of flash)
   #endif
 

--- a/config/examples/Creality/Ender-3 Pro/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Pro/Configuration_adv.h
@@ -1118,7 +1118,9 @@
   // Enable this option and set to HIGH if your SD cards are incorrectly detected.
   //#define SD_DETECT_STATE HIGH
 
-  //#define SDCARD_READONLY                 // Read-only SD card (to save over 2K of flash)
+  #if DISABLED(POWER_LOSS_RECOVERY)
+    #define SDCARD_READONLY                 // Read-only SD card (to save over 2K of flash)
+  #endif
 
   #define SD_PROCEDURE_DEPTH 1              // Increase if you need more nested M32 calls
 

--- a/config/examples/Creality/Ender-3 Pro/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Pro/Configuration_adv.h
@@ -1118,7 +1118,7 @@
   // Enable this option and set to HIGH if your SD cards are incorrectly detected.
   //#define SD_DETECT_STATE HIGH
 
-  #if DISABLED(POWER_LOSS_RECOVERY) && DISABLED(BINARY_FILE_TRANSFER) && DISABLED(SDCARD_EEPROM_EMULATION)
+  #if NONE(POWER_LOSS_RECOVERY, BINARY_FILE_TRANSFER, SDCARD_EEPROM_EMULATION)
     #define SDCARD_READONLY                 // Read-only SD card (to save over 2K of flash)
   #endif
 

--- a/config/examples/Creality/Ender-3/CrealityV1/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/CrealityV1/Configuration_adv.h
@@ -1118,10 +1118,10 @@
   // Enable this option and set to HIGH if your SD cards are incorrectly detected.
   //#define SD_DETECT_STATE HIGH
 
-  #if DISABLED(POWER_LOSS_RECOVERY) && DISABLED(BINARY_FILE_TRANSFER) && DISABLED(SDCARD_EEPROM_EMULATION)
+  #if NONE(POWER_LOSS_RECOVERY, BINARY_FILE_TRANSFER, SDCARD_EEPROM_EMULATION)
     #define SDCARD_READONLY                 // Read-only SD card (to save over 2K of flash)
   #endif
-  
+
   #define SD_PROCEDURE_DEPTH 1              // Increase if you need more nested M32 calls
 
   #define SD_FINISHED_STEPPERRELEASE true   // Disable steppers when SD Print is finished

--- a/config/examples/Creality/Ender-3/CrealityV1/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/CrealityV1/Configuration_adv.h
@@ -1118,8 +1118,10 @@
   // Enable this option and set to HIGH if your SD cards are incorrectly detected.
   //#define SD_DETECT_STATE HIGH
 
-  //#define SDCARD_READONLY                 // Read-only SD card (to save over 2K of flash)
-
+  #if DISABLED(POWER_LOSS_RECOVERY)
+    #define SDCARD_READONLY                 // Read-only SD card (to save over 2K of flash)
+  #endif
+  
   #define SD_PROCEDURE_DEPTH 1              // Increase if you need more nested M32 calls
 
   #define SD_FINISHED_STEPPERRELEASE true   // Disable steppers when SD Print is finished

--- a/config/examples/Creality/Ender-3/CrealityV1/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/CrealityV1/Configuration_adv.h
@@ -1118,7 +1118,7 @@
   // Enable this option and set to HIGH if your SD cards are incorrectly detected.
   //#define SD_DETECT_STATE HIGH
 
-  #if DISABLED(POWER_LOSS_RECOVERY)
+  #if DISABLED(POWER_LOSS_RECOVERY) && DISABLED(BINARY_FILE_TRANSFER) && DISABLED(SDCARD_EEPROM_EMULATION)
     #define SDCARD_READONLY                 // Read-only SD card (to save over 2K of flash)
   #endif
   


### PR DESCRIPTION
### Description
This PR automatically enables the SDCARD_READONLY option if no other feature like Power Loss Recovery, EEPROM Emulation or Binary File Transfer has to write to the SD card.

Please let me know what you think about this. Any feedback is welcome.

### Benefits
This saves 3214 bytes of flash storage when building the _melzi_ target without impacting the functionality.
With this change, the firmware fits into the stock motherboard again without using _melzi_optimized_.

### Related Issues
This fixes #173 for the Ender 3 and Ender 3-Pro
