### PR TITLE
Enable CDC serial over usb in config/examples/delta/MKS/SBASE

### DIFF
--- a/config/examples/delta/MKS/SBASE/Configuration.h
+++ b/config/examples/delta/MKS/SBASE/Configuration.h
@@ -104,7 +104,7 @@
  *
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-#define SERIAL_PORT 0
+#define SERIAL_PORT -1
 
 /**
  * Select a secondary serial port on the board to use for communication with the host.


### PR DESCRIPTION
### Description

CDC USB serial is disabled in this example config. 

### Benefits

CDC USB serial works

### Related Issues

Issue #212 