### PR TITLE
Fix Anet A8 Z axis stepper driver number

### DIFF
--- a/config/examples/Anet/A8/Configuration_adv.h
+++ b/config/examples/Anet/A8/Configuration_adv.h
@@ -548,7 +548,7 @@
 //
 // For Z set the number of stepper drivers
 //
-#define NUM_Z_STEPPER_DRIVERS 1   // (1-4) Z options change based on how many
+#define NUM_Z_STEPPER_DRIVERS 2   // (1-4) Z options change based on how many
 
 #if NUM_Z_STEPPER_DRIVERS > 1
   //#define Z_MULTI_ENDSTOPS


### PR DESCRIPTION
Anet A8 has a dual stepper driver / dual stepper motor configuration on the Z axis.
This PR fixes the NUM_Z_STEPPER_DRIVERS in the example configuration of the Anet A8.