### PR TITLE
E current should be 770mA on Ender-3 with BigTreeTech SKR Mini E3 1.2

### DIFF
--- a/config/examples/Creality/Ender-3/BigTreeTech SKR Mini E3 1.2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/BigTreeTech SKR Mini E3 1.2/Configuration_adv.h
@@ -2306,7 +2306,7 @@
   #endif
 
   #if AXIS_IS_TMC(E0)
-    #define E0_CURRENT      650
+    #define E0_CURRENT      770
     #define E0_MICROSTEPS    16
     #define E0_RSENSE         0.11
     #define E0_CHAIN_POS     -1


### PR DESCRIPTION
### Description

This fixes under-extrusion issues on the original **Ender-3** machine when using the **BTT Trinamic V1.2** board. The measured current on the **original** and **untouched** board that comes with this machine reports a value of **770mA** for the **extruder** **motor** (**0.77V** measured on **Vref** which translates to 0.77A or 770mA). The default value that is set in the configuration file is too low (**650** which corresponds to 650mA or 0.65A).

I tested on real hardware using the above mentioned board with the new setting and everything works as expected now and no motor overheating (it's only softly warm). Also the printer is using the original mechanical parts and no extra added stuff.

I haven't tested with other boards that use the same Trinamic drivers but I assume the setting should be the same as we're talking about stock parts like the extruder motor combined with Trinamic drivers so the current used to drive the motor should have the same value. I understand that maybe the default settings are lower in order to be safer but for someone that doesn't have too much knowledge of the let's say advanced settings this can cause frustration (for me it did already). The new value that I propose is safe anyways so I don't see any problem here (the extruder motor is a bigger one compared to the rest and it needs to be more capable hence the bigger current value that it needs to keep torque and to avoid missing steps).

See for yourself:
![proof](https://user-images.githubusercontent.com/2891463/95057826-59ec0800-06ff-11eb-8041-e6a912c86225.jpg)


### Benefits

Fixes under-extrusion and bad prints caused by the latter.
