### PR TITLE
Enable PROBE_OFFSET_WIZARD on BTT/Biqu Configs

### DIFF
--- a/config/examples/BIQU/B1-BLTouch/Configuration_adv.h
+++ b/config/examples/BIQU/B1-BLTouch/Configuration_adv.h
@@ -1052,7 +1052,7 @@
 
   // Add Probe Z Offset calibration to the Bed Leveling menu
   #if HAS_BED_PROBE
-    //#define PROBE_OFFSET_WIZARD
+    #define PROBE_OFFSET_WIZARD
     #if ENABLED(PROBE_OFFSET_WIZARD)
       #define PROBE_OFFSET_START -4.0   // Estimated nozzle-to-probe Z offset, plus a little extra
     #endif

--- a/config/examples/Prusa/MK3S-BigTreeTech-BTT002/Configuration_adv.h
+++ b/config/examples/Prusa/MK3S-BigTreeTech-BTT002/Configuration_adv.h
@@ -1052,7 +1052,7 @@
 
   // Add Probe Z Offset calibration to the Bed Leveling menu
   #if HAS_BED_PROBE
-    //#define PROBE_OFFSET_WIZARD
+    #define PROBE_OFFSET_WIZARD
     #if ENABLED(PROBE_OFFSET_WIZARD)
       #define PROBE_OFFSET_START -4.0   // Estimated nozzle-to-probe Z offset, plus a little extra
     #endif


### PR DESCRIPTION
### Description

Enable `PROBE_OFFSET_WIZARD` for the Prusa MK3S/BigTreeTech BTT002 & Biqu B1 w/ BLTouch configs.

### Benefits

Users can now set their probe offset with this new feature.

### Related Issues

None.
