### PR TITLE
Revert "770mA E Current on Ender-3 with SKR Mini E3 1.2 (#243)"

### DIFF
--- a/config/examples/Creality/Ender-3/BigTreeTech SKR Mini E3 1.2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/BigTreeTech SKR Mini E3 1.2/Configuration_adv.h
@@ -2331,7 +2331,7 @@
   #endif
 
   #if AXIS_IS_TMC(E0)
-    #define E0_CURRENT      770
+    #define E0_CURRENT      650
     #define E0_MICROSTEPS    16
     #define E0_RSENSE         0.11
     #define E0_CHAIN_POS     -1


### PR DESCRIPTION
### Description

This reverts commit 68d9287e2c40c18cdc63b6a73a4efbdb8a46b84b.

TMC current for the Ender-3 extruder stepper (and other Creality printers with the same stepper size) should be reverted back to 650. I added these in https://github.com/MarlinFirmware/Marlin/pull/15115 and https://github.com/MarlinFirmware/Marlin/pull/15666.

It doesn’t make sense why it’s all of a sudden not OK for one user with this board/stepper config, so it shouldn’t have been changed for everyone.

### Related Issues

PR #243