### PR TITLE
Fix Linear Advance for BTT SKR E3-DIP V1.x

### DIFF
--- a/config/examples/Creality/Ender-3/BigTreeTech SKR E3-DIP V1.1/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/BigTreeTech SKR E3-DIP V1.1/Configuration_adv.h
@@ -1653,7 +1653,7 @@
 #define LIN_ADVANCE
 #if ENABLED(LIN_ADVANCE)
   //#define EXTRA_LIN_ADVANCE_K // Enable for second linear advance constants
-  #define LIN_ADVANCE_K 0.22    // Unit: mm compression per 1mm/s extruder speed
+  #define LIN_ADVANCE_K 0.00    // Unit: mm compression per 1mm/s extruder speed
   //#define LA_DEBUG            // If enabled, this will generate debug information output over USB.
   #define EXPERIMENTAL_SCURVE   // Enable this option to permit S-Curve Acceleration
 #endif


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Set by default Linear Advance K=0 to avoid known problems with TMC2208 extruder driver.

### Benefits

This sets to default value K=0 which means disabled Linear Advance. So it implies a workaround to the issue.
Anyway a user can change K value by M900 command and enable Linear Advance without rebuild the firmware.

### Related Issues

This PR is a part of separating #269 into logically different units.
