### PR TITLE
Fix Tronxy X5SA Auto Fan pin format

### DIFF
--- a/config/examples/Tronxy/X5SA/Configuration_adv.h
+++ b/config/examples/Tronxy/X5SA/Configuration_adv.h
@@ -474,7 +474,7 @@
  * Multiple extruders can be assigned to the same pin in which case
  * the fan will turn on when any selected extruder is above the threshold.
  */
-#define E0_AUTO_FAN_PIN FAN_PIN_2
+#define E0_AUTO_FAN_PIN FAN2_PIN
 #define E1_AUTO_FAN_PIN -1
 #define E2_AUTO_FAN_PIN -1
 #define E3_AUTO_FAN_PIN -1


### PR DESCRIPTION
### Requirements

~~Requires https://github.com/MarlinFirmware/Marlin/pull/19874.~~ Merged!

### Description

Fix `E0_AUTO_FAN_PIN`/ `FAN2_PIN` format.

### Benefits

Use proper fan pin format.

### Related Issues

https://github.com/MarlinFirmware/Marlin/pull/19874
