### PR TITLE
Disable S_CURVE_ACCELERATION to avoid LIN_ADVANCE sanity check

### DIFF
--- a/config/examples/Creality/Ender-5 Plus/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/Configuration.h
@@ -837,7 +837,7 @@
  *
  * See https://github.com/synthetos/TinyG/wiki/Jerk-Controlled-Motion-Explained
  */
-#define S_CURVE_ACCELERATION
+//#define S_CURVE_ACCELERATION
 
 //===========================================================================
 //============================= Z Probe Options =============================

--- a/config/examples/Ortur 4/Configuration.h
+++ b/config/examples/Ortur 4/Configuration.h
@@ -829,7 +829,7 @@
  *
  * See https://github.com/synthetos/TinyG/wiki/Jerk-Controlled-Motion-Explained
  */
-#define S_CURVE_ACCELERATION
+//#define S_CURVE_ACCELERATION
 
 //===========================================================================
 //============================= Z Probe Options =============================


### PR DESCRIPTION
### Description

Two examples enable both S_CURVE_ACCELERATION and LIN_ADVANCE. This breaks the builds due to a sanity check.
I have disabled S_CURVE_ACCELERATION to avoid this.

### Benefits

Examples build.

### Related Issues

N/A
