### PR TITLE
Update broken TFT Configurations

### DIFF
--- a/config/examples/delta/Anycubic/Predator/Configuration.h
+++ b/config/examples/delta/Anycubic/Predator/Configuration.h
@@ -111,7 +111,6 @@
  * :[-2, -1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
 #define SERIAL_PORT_2 3
-#define NUM_SERIAL 2
 
 /**
  * This setting determines the communication speed of the printer.
@@ -788,7 +787,6 @@
 //=============================================================================
 // @section motion
 
-// delta speeds must be the same on xyz
 /**
  * Default Settings
  *
@@ -2364,7 +2362,7 @@
 //
 // 480x320, 3.5", FSMC Stock Display from AnyCubic
 //
-//#define ANYCUBIC_TFT35
+#define ANYCUBIC_TFT35
 
 //
 // 320x240, 2.8", FSMC Stock Display from Longer/Alfawise
@@ -2374,17 +2372,17 @@
 //
 // Generic TFT with detailed options
 //
-#define TFT_GENERIC
+//#define TFT_GENERIC
 #if ENABLED(TFT_GENERIC)
   // :[ 'AUTO', 'ST7735', 'ST7789', 'ST7796', 'R61505', 'ILI9328', 'ILI9341', 'ILI9488' ]
   #define TFT_DRIVER AUTO
 
   // Interface. Enable one of the following options:
-  #define TFT_INTERFACE_FSMC
+  //#define TFT_INTERFACE_FSMC
   //#define TFT_INTERFACE_SPI
 
   // TFT Resolution. Enable one of the following options:
-  #define TFT_RES_320x240
+  //#define TFT_RES_320x240
   //#define TFT_RES_480x272
   //#define TFT_RES_480x320
 #endif

--- a/config/examples/delta/Anycubic/Predator/Configuration_adv.h
+++ b/config/examples/delta/Anycubic/Predator/Configuration_adv.h
@@ -1566,23 +1566,12 @@
 // Classic UI Options
 //
 #if TFT_SCALED_DOGLCD
-  //
-  // FSMC_UPSCALE 2 2x upscaler for 320x240 displays (default)
-  // FSMC_UPSCALE 3 3x upscaler for 480x320 displays
-  //
-  #define FSMC_UPSCALE 3
-
-  //
-  // Change colors
-  // some colors are predefined, see /src/lcd/dogm/u8g_dev_tft_480~.cpp Line 160
-  // or use 16bit color (e.g. 0x0000 = black, 0xFFE0 = yellow)
-  // see https://ee-programming-notepad.blogspot.com/2016/10/16-bit-color-generator-picker.html
-  //
-  #define TFT_MARLINUI_COLOR COLOR_WHITE // Main foreground color
-  #define TFT_MARLINBG_COLOR COLOR_BLACK // Background color
-  #define TFT_BTCANCEL_COLOR COLOR_RED   // Cancel button
-  #define TFT_BTARROWS_COLOR COLOR_WHITE // Arrows up/down
-  #define TFT_BTOKMENU_COLOR COLOR_NAVY  // Enter button
+  //#define TFT_MARLINUI_COLOR 0xFFFF // White
+  //#define TFT_MARLINBG_COLOR 0x0000 // Black
+  //#define TFT_DISABLED_COLOR 0x0003 // Almost black
+  //#define TFT_BTCANCEL_COLOR 0xF800 // Red
+  //#define TFT_BTARROWS_COLOR 0xDEE6 // 11011 110111 00110 Yellow
+  //#define TFT_BTOKMENU_COLOR 0x145F // 00010 100010 11111 Cyan
 #endif
 
 //

--- a/config/examples/delta/FLSUN/Q5-nano_v1/Configuration.h
+++ b/config/examples/delta/FLSUN/Q5-nano_v1/Configuration.h
@@ -2394,9 +2394,9 @@
  *   For LVGL_UI also copy the 'assets' folder from the build directory to the
  *   root of your SD card, together with the compiled firmware.
  */
-//#define TFT_CLASSIC_UI
+#define TFT_CLASSIC_UI
 //#define TFT_COLOR_UI
-#define TFT_LVGL_UI
+//#define TFT_LVGL_UI
 
 /**
  * TFT Rotation. Set to one of the following values:


### PR DESCRIPTION
### Description

Update TFT configurations for two machines.

** I do not have these printers, and cannot test these configurations. I attempted to determine the appropriate change to resolve build errors, without any ability to actually verify. **

**Anycubic Predator**
- Use preconfigured `ANYCUBIC_TFT35`. This was already set in the pins file, causing a conflict with `TFT_GENERIC`
- Update several lines from default configuration files, which are no longer needed.
- Remove unnecessary NUM_SERIAL in config file

** FLSUN Q5 nano-v1 **
- Switch from LVGL to Classic UI, because the screen resolution is insufficient for LVGL.

### Benefits

Examples are buildable.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/19576