### PR TITLE
Fix examples which fail display count sanity check

### DIFF
--- a/config/examples/3DFabXYZ/Migbot/Configuration.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration.h
@@ -1922,7 +1922,7 @@
 //
 // Generic 16x2, 16x4, 20x2, or 20x4 character-based LCD.
 //
-#define ULTRA_LCD
+//#define ULTRA_LCD
 
 //=============================================================================
 //======================== LCD / Controller Selection =========================

--- a/config/examples/Anet/E10/Configuration.h
+++ b/config/examples/Anet/E10/Configuration.h
@@ -1989,10 +1989,7 @@
 // RepRapDiscount FULL GRAPHIC Smart Controller
 // https://reprap.org/wiki/RepRapDiscount_Full_Graphic_Smart_Controller
 //
-#define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
-#define ST7920_DELAY_1 DELAY_NS(250)
-#define ST7920_DELAY_2 DELAY_NS(250)
-#define ST7920_DELAY_3 DELAY_NS(250)
+//#define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
 
 //
 // ReprapWorld Graphical LCD
@@ -2093,6 +2090,9 @@
 // different pins/wiring (see pins_ANET_10.h).
 //
 #define ANET_FULL_GRAPHICS_LCD
+#define ST7920_DELAY_1 DELAY_NS(250)
+#define ST7920_DELAY_2 DELAY_NS(250)
+#define ST7920_DELAY_3 DELAY_NS(250)
 
 //
 // AZSMZ 12864 LCD with SD

--- a/config/examples/BQ/WITBOX/Configuration.h
+++ b/config/examples/BQ/WITBOX/Configuration.h
@@ -1895,7 +1895,7 @@
 //
 // Generic 16x2, 16x4, 20x2, or 20x4 character-based LCD.
 //
-#define ULTRA_LCD
+//#define ULTRA_LCD
 
 //=============================================================================
 //======================== LCD / Controller Selection =========================

--- a/config/examples/EXP3D/Imprimante multifonction/Configuration.h
+++ b/config/examples/EXP3D/Imprimante multifonction/Configuration.h
@@ -1855,7 +1855,7 @@
 //
 // ULTIPANEL as seen on Thingiverse.
 //
-#define ULTIPANEL
+//#define ULTIPANEL
 
 //
 // PanelOne from T3P3 (via RAMPS 1.4 AUX2/AUX3)

--- a/config/examples/Geeetech/A10D/Configuration.h
+++ b/config/examples/Geeetech/A10D/Configuration.h
@@ -1856,8 +1856,8 @@
 //
 // ULTIPANEL as seen on Thingiverse.
 //
-#define ULTIPANEL
-//
+//#define ULTIPANEL
+
 // PanelOne from T3P3 (via RAMPS 1.4 AUX2/AUX3)
 // https://reprap.org/wiki/PanelOne
 //

--- a/config/examples/Geeetech/A30/Configuration.h
+++ b/config/examples/Geeetech/A30/Configuration.h
@@ -1855,7 +1855,7 @@
 //
 // ULTIPANEL as seen on Thingiverse.
 //
-#define ULTIPANEL
+//#define ULTIPANEL
 
 //
 // PanelOne from T3P3 (via RAMPS 1.4 AUX2/AUX3)

--- a/config/examples/Geeetech/D200/Configuration.h
+++ b/config/examples/Geeetech/D200/Configuration.h
@@ -1855,7 +1855,7 @@
 //
 // ULTIPANEL as seen on Thingiverse.
 //
-#define ULTIPANEL
+//#define ULTIPANEL
 
 //
 // PanelOne from T3P3 (via RAMPS 1.4 AUX2/AUX3)

--- a/config/examples/Geeetech/E180/Configuration.h
+++ b/config/examples/Geeetech/E180/Configuration.h
@@ -1856,7 +1856,7 @@
 //
 // ULTIPANEL as seen on Thingiverse.
 //
-#define ULTIPANEL
+//#define ULTIPANEL
 
 //
 // PanelOne from T3P3 (via RAMPS 1.4 AUX2/AUX3)

--- a/config/examples/Geeetech/M201/Configuration.h
+++ b/config/examples/Geeetech/M201/Configuration.h
@@ -1855,7 +1855,7 @@
 //
 // ULTIPANEL as seen on Thingiverse.
 //
-#define ULTIPANEL
+//#define ULTIPANEL
 
 //
 // PanelOne from T3P3 (via RAMPS 1.4 AUX2/AUX3)

--- a/config/examples/Geeetech/PI3A PRO/Configuration.h
+++ b/config/examples/Geeetech/PI3A PRO/Configuration.h
@@ -1865,7 +1865,7 @@
 //
 // ULTIPANEL as seen on Thingiverse.
 //
-#define ULTIPANEL
+//#define ULTIPANEL
 
 //
 // PanelOne from T3P3 (via RAMPS 1.4 AUX2/AUX3)

--- a/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -1905,7 +1905,7 @@
 //
 // Generic 16x2, 16x4, 20x2, or 20x4 character-based LCD.
 //
-#define ULTRA_LCD
+//#define ULTRA_LCD
 
 //=============================================================================
 //======================== LCD / Controller Selection =========================

--- a/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -1904,7 +1904,7 @@
 //
 // Generic 16x2, 16x4, 20x2, or 20x4 character-based LCD.
 //
-#define ULTRA_LCD
+//#define ULTRA_LCD
 
 //=============================================================================
 //======================== LCD / Controller Selection =========================

--- a/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -1895,7 +1895,7 @@
 //
 // Generic 16x2, 16x4, 20x2, or 20x4 character-based LCD.
 //
-#define ULTRA_LCD
+//#define ULTRA_LCD
 
 //=============================================================================
 //======================== LCD / Controller Selection =========================

--- a/config/examples/delta/Geeetech/G2/Configuration.h
+++ b/config/examples/delta/Geeetech/G2/Configuration.h
@@ -1952,7 +1952,7 @@
 //
 // ULTIPANEL as seen on Thingiverse.
 //
-#define ULTIPANEL
+//#define ULTIPANEL
 
 //
 // PanelOne from T3P3 (via RAMPS 1.4 AUX2/AUX3)

--- a/config/examples/delta/Geeetech/G2Pro/Configuration.h
+++ b/config/examples/delta/Geeetech/G2Pro/Configuration.h
@@ -1952,7 +1952,7 @@
 //
 // ULTIPANEL as seen on Thingiverse.
 //
-#define ULTIPANEL
+//#define ULTIPANEL
 
 //
 // PanelOne from T3P3 (via RAMPS 1.4 AUX2/AUX3)

--- a/config/examples/delta/Geeetech/G2S/Configuration.h
+++ b/config/examples/delta/Geeetech/G2S/Configuration.h
@@ -1952,7 +1952,7 @@
 //
 // ULTIPANEL as seen on Thingiverse.
 //
-#define ULTIPANEL
+//#define ULTIPANEL
 
 //
 // PanelOne from T3P3 (via RAMPS 1.4 AUX2/AUX3)

--- a/config/examples/delta/Geeetech/G2SPro/Configuration.h
+++ b/config/examples/delta/Geeetech/G2SPro/Configuration.h
@@ -1952,7 +1952,7 @@
 //
 // ULTIPANEL as seen on Thingiverse.
 //
-#define ULTIPANEL
+//#define ULTIPANEL
 
 //
 // PanelOne from T3P3 (via RAMPS 1.4 AUX2/AUX3)

--- a/config/examples/delta/kossel_clear/Configuration.h
+++ b/config/examples/delta/kossel_clear/Configuration.h
@@ -1953,7 +1953,7 @@
 //
 // ULTIPANEL as seen on Thingiverse.
 //
-#define ULTIPANEL
+//#define ULTIPANEL
 
 //
 // PanelOne from T3P3 (via RAMPS 1.4 AUX2/AUX3)


### PR DESCRIPTION
### Description

Multiple configurations had both REPRAP_DISCOUNT_SMART_CONTROLLER and either ULTRA_LCD or ULTIPANEL selected.
This fails a sanity check which verifies only one display is selected. I believe the REPRAP_DISCOUNT_SMART_CONTROLLER
already defines anything that could have come from the other displays.

The ANET E10 also had a similar problem, but it defined
REPRAP_DISCOUNT_FULL_GRAPHICS_SMART_CONTROLLER along with an ANET
display.

### Benefits

Examples build.

### Related Issues

N/A
