### PR TITLE
Revert broken PID settings for FLSUN/Q5

### DIFF
--- a/config/examples/delta/FLSUN/Q5-nano_v2/Configuration.h
+++ b/config/examples/delta/FLSUN/Q5-nano_v2/Configuration.h
@@ -503,10 +503,9 @@
     #define DEFAULT_Ki_LIST {   1.08,   1.0 }
     #define DEFAULT_Kd_LIST { 114.00, 112.0 }
   #else
-    // flsun Q5 via M303 C8 E-1 S60
-    #define DEFAULT_bedKp 80.77
-    #define DEFAULT_bedKi 15.74
-    #define DEFAULT_bedKd 276.27
+    #define DEFAULT_Kp  22.20
+    #define DEFAULT_Ki   1.08
+    #define DEFAULT_Kd 114.00
   #endif
 #endif // PIDTEMP
 


### PR DESCRIPTION
### Description

PID settings incorrectly use the names for bed PID.

### Benefits

Fixes build.

### Related Issues

N/A
