### PR TITLE
Disable features on sanguino1284p examples that don't fit in flash

### DIFF
--- a/config/examples/Anet/E16/Configuration.h
+++ b/config/examples/Anet/E16/Configuration.h
@@ -1756,7 +1756,7 @@
  * just remove some extraneous menu items to recover space.
  */
 //#define NO_LCD_MENUS
-//#define SLIM_LCD_MENUS
+#define SLIM_LCD_MENUS
 
 //
 // ENCODER SETTINGS

--- a/config/examples/Geeetech/Me_ducer/Configuration_adv.h
+++ b/config/examples/Geeetech/Me_ducer/Configuration_adv.h
@@ -1791,7 +1791,7 @@
 //
 // G2/G3 Arc Support
 //
-#define ARC_SUPPORT                 // Disable this feature to save ~3226 bytes
+//#define ARC_SUPPORT                 // Disable this feature to save ~3226 bytes
 #if ENABLED(ARC_SUPPORT)
   #define MM_PER_ARC_SEGMENT      1 // (mm) Length (or minimum length) of each arc segment
   //#define ARC_SEGMENTS_PER_R    1 // Max segment length, MM_PER = Min


### PR DESCRIPTION
### Description

Two `sanguino1284p` examples are too large to build. Disable features to make them fit. I only did this for boards which only list `sanguino1284p` as a possible environment.

I did not update examples which use boards specifying `melzi` as a possible environment, since for those boards users can switch to Optiboot and use the `melzi_optimized` environment.

### Benefits

Examples builds for `sanguino1284p`.

### Related Issues

N/A
