### PR TITLE
Enable PROBE_MANUALLY for M300

### DIFF
--- a/config/examples/delta/Malyan M300/Configuration.h
+++ b/config/examples/delta/Malyan M300/Configuration.h
@@ -943,7 +943,7 @@
  * Use G29 repeatedly, adjusting the Z height at each point with movement commands
  * or (with LCD_BED_LEVELING) the LCD controller.
  */
-//#define PROBE_MANUALLY
+#define PROBE_MANUALLY
 //#define MANUAL_PROBE_START_Z 0.2
 
 /**


### PR DESCRIPTION
### Description

The Malyan M300 example enable bed leveling, but does not have a probe. Enable `PROBE_MANUALLY` to allow the example to compile.

Alternatively, all features requiring a probe could be disabled.

### Benefits

Example builds.

### Related Issues

N/A
