### PR TITLE
Add important SD card information for Ender 5 plus DGUS Display flashing.

### DIFF
--- a/config/examples/Creality/Ender-5 Plus/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/Configuration.h
@@ -2173,8 +2173,9 @@
 //
 // DGUS Touch Display with DWIN OS. (Choose one.)
 // Flash display with DGUS Displays for Marlin:
-// 1.) Copy DWIN_SET folder from [1] to SD card,
-// 2.) boot the display with SD plugged into its own SD reader (not the motherboard's).
+// 1.) Format the SD card to FAT32 with a allocation size of 4k
+// 2.) Copy DWIN_SET folder from [1] to SD card,
+// 3.) boot the display with SD plugged into its own SD reader (not the motherboard's).
 // [1] https://github.com/coldtobi/Marlin_DGUS_Resources
 #define DGUS_LCD_UI_ORIGIN
 //#define DGUS_LCD_UI_FYSETC

--- a/config/examples/Creality/Ender-5 Plus/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/Configuration.h
@@ -2172,11 +2172,14 @@
 
 //
 // DGUS Touch Display with DWIN OS. (Choose one.)
+//
 // Flash display with DGUS Displays for Marlin:
-// 1.) Format the SD card to FAT32 with a allocation size of 4k
-// 2.) Copy DWIN_SET folder from [1] to SD card,
-// 3.) boot the display with SD plugged into its own SD reader (not the motherboard's).
-// [1] https://github.com/coldtobi/Marlin_DGUS_Resources
+//  1. Format the SD card to FAT32 with a allocation size of 4k.
+//  2. Download https://github.com/coldtobi/Marlin_DGUS_Resources
+//  3. Copy the downloaded DWIN_SET folder to the SD card.
+//  4. Plug the microSD card into the back of the display.
+//  4. Boot the display and wait for the update to complete.
+//
 #define DGUS_LCD_UI_ORIGIN
 //#define DGUS_LCD_UI_FYSETC
 //#define DGUS_LCD_UI_HIPRECY


### PR DESCRIPTION
### Requirements

 DGUS Touch Display with DWIN OS

### Description

If you attempt to upgrade the DGUS Displays with the data from the DWIN_SET folder and the SD card is not formatted correctly It will not work. 
It displays that 0 files are loaded.
eg
![DWIN Error](https://user-images.githubusercontent.com/530024/97107524-f157e000-172c-11eb-9e29-8c480466a0d4.jpg)
But does not tell you why. 
Incorrect formatting of the SD card is why.

### Benefits

Users who read the note in the Config will be able to update the DGUS Display.