### PR TITLE
Rotate LCD by 180 for stock Anycubic Predator

### DIFF
--- a/config/examples/delta/Anycubic/Predator/Configuration.h
+++ b/config/examples/delta/Anycubic/Predator/Configuration.h
@@ -2396,7 +2396,6 @@
 // 480x320, 3.5", FSMC Stock Display from AnyCubic
 //
 #define ANYCUBIC_TFT35
-#define TFT_ROTATION TFT_ROTATE_180
 
 //
 // 320x240, 2.8", FSMC Stock Display from Longer/Alfawise
@@ -2443,7 +2442,7 @@
  *   TFT_ROTATE_270, TFT_ROTATE_270_MIRROR_X, TFT_ROTATE_270_MIRROR_Y,
  *   TFT_MIRROR_X, TFT_MIRROR_Y, TFT_NO_ROTATION
  */
-//#define TFT_ROTATION TFT_NO_ROTATION
+#define TFT_ROTATION TFT_ROTATE_180
 
 //=============================================================================
 //============================  Other Controllers  ============================

--- a/config/examples/delta/Anycubic/Predator/Configuration.h
+++ b/config/examples/delta/Anycubic/Predator/Configuration.h
@@ -2396,6 +2396,7 @@
 // 480x320, 3.5", FSMC Stock Display from AnyCubic
 //
 #define ANYCUBIC_TFT35
+#define TFT_ROTATION TFT_ROTATE_180
 
 //
 // 320x240, 2.8", FSMC Stock Display from Longer/Alfawise


### PR DESCRIPTION
Rotate LCD by 180 degrees for stock Anycubic Predator.

### Description

The stock Anycubic Predator LCD needs rotated by 180 degrees.  

### Benefits

This fix improves general usability of the LCD, or saves them from having to physically rotate it.

### Related Issues

None
