### PR TITLE
Fix touch calibration values for classic ui

### DIFF
--- a/config/examples/delta/Anycubic/Predator/Configuration.h
+++ b/config/examples/delta/Anycubic/Predator/Configuration.h
@@ -2466,10 +2466,10 @@
 
   #define TOUCH_SCREEN_CALIBRATION
 
-  #define TOUCH_CALIBRATION_X 12316
-  #define TOUCH_CALIBRATION_Y -8981
-  #define TOUCH_OFFSET_X        -43
-  #define TOUCH_OFFSET_Y        257
+  #define TOUCH_CALIBRATION_X  16810
+  #define TOUCH_CALIBRATION_Y -11570
+  #define TOUCH_OFFSET_X         -13
+  #define TOUCH_OFFSET_Y         338
 
   #if ENABLED(TFT_COLOR_UI)
     //#define SINGLE_TOUCH_NAVIGATION


### PR DESCRIPTION
Now that classic don't have fixed touch coordinates at 320x240 and uses fully screen resolution, we need to fix those old calibration values. This are the new calibration values for this board.