### PR TITLE
Replace PROBE_OFFSET_START with PROBE_OFFSET_WIZARD_START_Z.

### DIFF
--- a/config/examples/Creality/Ender-3/CrealityV422/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/CrealityV422/Configuration_adv.h
@@ -1084,7 +1084,7 @@
   #if HAS_BED_PROBE
     //#define PROBE_OFFSET_WIZARD
     #if ENABLED(PROBE_OFFSET_WIZARD)
-      #define PROBE_OFFSET_START -4.0   // Estimated nozzle-to-probe Z offset, plus a little extra
+      #define PROBE_OFFSET_WIZARD_START_Z -4.0   // Estimated nozzle-to-probe Z offset, plus a little extra
       //#define PROBE_OFFSET_WIZARD_XY_POS XY_CENTER // Set a convenient position to do the measurement
     #endif
   #endif

--- a/config/examples/Two Trees/Sapphire Pro/Configuration_adv.h
+++ b/config/examples/Two Trees/Sapphire Pro/Configuration_adv.h
@@ -1084,7 +1084,7 @@
   #if HAS_BED_PROBE
     #define PROBE_OFFSET_WIZARD
     #if ENABLED(PROBE_OFFSET_WIZARD)
-      #define PROBE_OFFSET_START -2.0   // Estimated nozzle-to-probe Z offset, plus a little extra
+      #define PROBE_OFFSET_WIZARD_START_Z -2.0   // Estimated nozzle-to-probe Z offset, plus a little extra
       //#define PROBE_OFFSET_WIZARD_XY_POS XY_CENTER // Set a convenient position to do the measurement
     #endif
   #endif


### PR DESCRIPTION
### Description

Fix compilation error when using Configurations branch import-2.0.x vs Marlin branch bugfix-2.0.x as of this commit https://github.com/MarlinFirmware/Marlin/commit/c353eab8989878d8c47603d1f87e6179129877d0

Only tested with Two Trees/Sapphire Pro build, but Creality/Ender-3/CrealityV422 references the same variable.

### Benefits

Without this PR, compilation error.
```
Compiling .pio\build\mks_robin_nano35\src\src\HAL\STM32F1\eeprom_flash.cpp.o
In file included from Marlin\src\HAL\STM32F1\../../inc/MarlinConfig.h:49:0,
                 from Marlin\src\HAL\STM32F1\HAL.cpp:30:
Marlin\src\HAL\STM32F1\../../inc/SanityCheck.h:531:4: error: #error "PROBE_OFFSET_START is now PROBE_OFFSET_WIZARD_START_Z."
   #error "PROBE_OFFSET_START is now PROBE_OFFSET_WIZARD_START_Z."
    ^~~~~
In file included from Marlin\src\HAL\STM32F1\../../inc/MarlinConfig.h:49:0,
                 from Marlin\src\HAL\STM32F1\HAL_SPI.cpp:32:
Marlin\src\HAL\STM32F1\../../inc/SanityCheck.h:531:4: error: #error "PROBE_OFFSET_START is now PROBE_OFFSET_WIZARD_START_Z."
   #error "PROBE_OFFSET_START is now PROBE_OFFSET_WIZARD_START_Z."
    ^~~~~
In file included from Marlin\src\HAL\STM32F1\../../inc/MarlinConfig.h:49:0,
                 from Marlin\src\HAL\STM32F1\MarlinSerial.cpp:25:
Marlin\src\HAL\STM32F1\../../inc/SanityCheck.h:531:4: error: #error "PROBE_OFFSET_START is now PROBE_OFFSET_WIZARD_START_Z."
   #error "PROBE_OFFSET_START is now PROBE_OFFSET_WIZARD_START_Z."
    ^~~~~
*** [.pio\build\mks_robin_nano35\src\src\HAL\STM32F1\HAL.cpp.o] Error 1
In file included from Marlin\src\HAL\STM32F1\../../inc/MarlinConfig.h:49:0,
                 from Marlin\src\HAL\STM32F1\SPI.cpp:43:
Marlin\src\HAL\STM32F1\../../inc/SanityCheck.h:531:4: error: #error "PROBE_OFFSET_START is now PROBE_OFFSET_WIZARD_START_Z."
   #error "PROBE_OFFSET_START is now PROBE_OFFSET_WIZARD_START_Z."
    ^~~~~
In file included from Marlin\src\HAL\STM32F1\../../inc/MarlinConfig.h:49:0,
                 from Marlin\src\HAL\STM32F1\Servo.cpp:25:
Marlin\src\HAL\STM32F1\../../inc/SanityCheck.h:531:4: error: #error "PROBE_OFFSET_START is now PROBE_OFFSET_WIZARD_START_Z."
   #error "PROBE_OFFSET_START is now PROBE_OFFSET_WIZARD_START_Z."
    ^~~~~
*** [.pio\build\mks_robin_nano35\src\src\HAL\STM32F1\HAL_SPI.cpp.o] Error 1
*** [.pio\build\mks_robin_nano35\src\src\HAL\STM32F1\MarlinSerial.cpp.o] Error 1
                 from Marlin\src\HAL\STM32F1\dogm\u8g_com_stm32duino_swspi.cpp:21:
Marlin\src\HAL\STM32F1\dogm\../../../inc/SanityCheck.h:531:4: error: #error "PROBE_OFFSET_START is now PROBE_OFFSET_WIZARD_START_Z."
   #error "PROBE_OFFSET_START is now PROBE_OFFSET_WIZARD_START_Z."
    ^~~~~
*** [.pio\build\mks_robin_nano35\src\src\HAL\STM32F1\SPI.cpp.o] Error 1
In file included from Marlin\src\HAL\STM32F1\../../inc/MarlinConfig.h:49:0,
                 from Marlin\src\HAL\STM32F1\eeprom_bl24cxx.cpp:30:
Marlin\src\HAL\STM32F1\../../inc/SanityCheck.h:531:4: error: #error "PROBE_OFFSET_START is now PROBE_OFFSET_WIZARD_START_Z."
   #error "PROBE_OFFSET_START is now PROBE_OFFSET_WIZARD_START_Z."
    ^~~~~
*** [.pio\build\mks_robin_nano35\src\src\HAL\STM32F1\Servo.cpp.o] Error 1
In file included from Marlin\src\HAL\STM32F1\../../inc/MarlinConfig.h:49:0,
                 from Marlin\src\HAL\STM32F1\eeprom_flash.cpp:32:
Marlin\src\HAL\STM32F1\../../inc/SanityCheck.h:531:4: error: #error "PROBE_OFFSET_START is now PROBE_OFFSET_WIZARD_START_Z."
   #error "PROBE_OFFSET_START is now PROBE_OFFSET_WIZARD_START_Z."
    ^~~~~
*** [.pio\build\mks_robin_nano35\src\src\HAL\STM32F1\dogm\u8g_com_stm32duino_swspi.cpp.o] Error 1
*** [.pio\build\mks_robin_nano35\src\src\HAL\STM32F1\eeprom_bl24cxx.cpp.o] Error
```
With PR, successful build.
