### PR TITLE
Enable Biqu B1 BLTouch Probe Offset Wizard Position

### DIFF
--- a/config/examples/BIQU/B1-BLTouch/Configuration_adv.h
+++ b/config/examples/BIQU/B1-BLTouch/Configuration_adv.h
@@ -1089,7 +1089,7 @@
       //#define PROBE_OFFSET_WIZARD_START_Z -4.0
 
       // Set a convenient position to do the calibration (probing point and nozzle/bed-distance)
-      //#define PROBE_OFFSET_WIZARD_XY_POS { X_CENTER, Y_CENTER }
+      #define PROBE_OFFSET_WIZARD_XY_POS { X_CENTER, Y_CENTER }
     #endif
   #endif
 


### PR DESCRIPTION
### Description

The Biqu B1 homes with a Z endstop, so this ensures that the Probe Offset Wizard will deploy the BLTouch in the center of the bed.

### Benefits

Ensure Probe Offset Wizard deploys BLTouch in the center of the bed.

### Related Issues

None