### PR TITLE
Update homing speed variables.

### DIFF
--- a/config/examples/Geeetech/A10/Configuration.h
+++ b/config/examples/Geeetech/A10/Configuration.h
@@ -1498,7 +1498,8 @@
 #endif
 
 // Homing speeds (mm/min)
-#define HOMING_FEEDRATE_MM_M { (80*60), (80*60), (20*60) }
+#define HOMING_FEEDRATE_XY (80 * 60)
+#define HOMING_FEEDRATE_Z (20 * 60)
 
 // Validate that endstops are triggered on homing moves
 #define VALIDATE_HOMING_ENDSTOPS


### PR DESCRIPTION
The Geeetech A10 Configuration is not compiling. This is caused by the [`Configuration.h`](config\examples\Geeetech\A10\Configuration.h) file, which is not updated. It contains the [`HOMING_FEEDRATE_MM_M`](https://github.com/MarlinFirmware/Configurations/blob/77f5891304aa05e85394a25c2f3ce63ac97b7013/config/examples/Geeetech/A10/Configuration.h#L1501) variable for setting up the [homing speed](https://marlinfw.org/docs/configuration/configuration.html#homing-options) that now looks like it's replace by `HOMING_FEEDRATE_XY` and `HOMING_FEEDRATE_Z`.

### Description
As described, the variable:
```c++
#define HOMING_FEEDRATE_MM_M { (80*60), (80*60), (20*60) }
```
was removed and instead, defined `HOMING_FEEDRATE_XY` and `HOMING_FEEDRATE_Z`:
```c++
#define HOMING_FEEDRATE_XY (80 * 60)
#define HOMING_FEEDRATE_Z (20 * 60)
```

### Benefits
The build can now compile. Also, a test print was done with good results.

### Related Issues
File not updated! With a [quik search](), looks like many configs need this update. If this pull is approved, I have no problem updating the rest of the files. Also, a recent issue (#378) commented on this issue.
