### PR TITLE
Fix CR-10 V2 with BLTouch

### DIFF
--- a/config/examples/Creality/CR-10 V2/Configuration.h
+++ b/config/examples/Creality/CR-10 V2/Configuration.h
@@ -658,10 +658,10 @@
 // Mechanical endstop with COM to ground and NC to Signal uses "false" here (most common setup).
 #define X_MIN_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
 #define Y_MIN_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
-#define Z_MIN_ENDSTOP_INVERTING ENABLED(CR10V2_BLTOUCH) // Set to true to invert the logic of the endstop.
+#define Z_MIN_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
 #define X_MAX_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
 #define Y_MAX_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
-#define Z_MAX_ENDSTOP_INVERTING ENABLED(CR10V2_BLTOUCH) // Set to true to invert the logic of the endstop.
+#define Z_MAX_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
 #define Z_MIN_PROBE_ENDSTOP_INVERTING ENABLED(CR10V2_BLTOUCH) // Set to true to invert the logic of the probe.
 
 /**
@@ -845,11 +845,13 @@
  * The probe replaces the Z-MIN endstop and is used for Z homing.
  * (Automatically enables USE_PROBE_FOR_Z_HOMING.)
  */
-#define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
+//#define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 // Force the use of the probe for Z-axis homing
 //#define USE_PROBE_FOR_Z_HOMING
-
+#if ENABLED(CR10V2_BLTOUCH)
+  #define USE_PROBE_FOR_Z_HOMING
+#endif
 /**
  * Z_MIN_PROBE_PIN
  *
@@ -868,7 +870,7 @@
 //#define Z_MIN_PROBE_PIN 32 // Pin 32 is the RAMPS default
 
 #if ENABLED(CR10V2_BLTOUCH)
-  #define Z_STOP_PIN 19 // Source DWIN2
+  #define Z_MIN_PROBE_PIN 19
 #endif
 
 /**


### PR DESCRIPTION
Allow Z_MIN_ENDSTOP to retain functionality after enabling CR10V2_BLTOUCH

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
