### PR TITLE
Add missing precompiler directives

### DIFF
--- a/config/examples/Creality/Ender-3/CrealityV1/Configuration.h
+++ b/config/examples/Creality/Ender-3/CrealityV1/Configuration.h
@@ -1494,7 +1494,9 @@
 #endif
 
 // Homing speeds (mm/min)
-#define HOMING_FEEDRATE_MM_M { (20*60), (20*60), (4*60) }
+#define HOMING_FEEDRATE_Z  (4*60)
+#define HOMING_FEEDRATE_XY  (20*60)
+#define HOMING_FEEDRATE_MM_M { HOMING_FEEDRATE_XY, HOMING_FEEDRATE_XY, HOMING_FEEDRATE_Z }
 
 // Validate that endstops are triggered on homing moves
 #define VALIDATE_HOMING_ENDSTOPS


### PR DESCRIPTION
### Description

This fixes the build error described here: https://gitmemory.com/issue/MarlinFirmware/Marlin/20623/753316550

Summarized as: 
`sketch\src\module\motion.cpp:151:16: error: 'HOMING_FEEDRATE_XY' was not declared in this scope`

This is for the Ender 3 V1 board.

### Benefits

This allows Marlin to compile for the Ender 3 V1 board.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
