### PR TITLE
replace HOMING_FEEDRATE_MM_M with HOMING_FEEDRATE_XY and HOMING_FEEDR…

### DIFF
--- a/config/examples/Anet/A8/Configuration.h
+++ b/config/examples/Anet/A8/Configuration.h
@@ -1496,7 +1496,8 @@
 #endif
 
 // Homing speeds (mm/min)
-#define HOMING_FEEDRATE_MM_M { (100*60), (100*60), (4*60) }
+#define HOMING_FEEDRATE_XY (100*60)
+#define HOMING_FEEDRATE_Z (4*60)
 
 // Validate that endstops are triggered on homing moves
 #define VALIDATE_HOMING_ENDSTOPS


### PR DESCRIPTION
replace HOMING_FEEDRATE_MM_M with HOMING_FEEDRATE_XY and HOMING_FEEDRATE_Z in Anet A8 example Configuration.h

### Requirements

No Requirements are needed for this.

### Description

The current Anet A8 Configuration.h uses the Homing Speeds #define HOMING_FEEDRATE_MM_M. When importing the Configuration.h to Marlin and try to compile it, the Arduino IDE throws several errors regarding not recognizing HOMING_FEEDRATE_MM_M. Looking at the Configuration that comes with Marlin the Homing Speeds define is now separated into
#define HOMING_FEEDRATE_XY
#define HOMING_FEEDRATE_Z

I adapted the Anet A8 Configuration.h to that.

### Benefits

Compiling the Project works again for Anet A8 users. It is up and running on my Anet A8.

### Related Issues

No Issue was opened for this.
