### PR TITLE
AnyCubic Predator - filament runout sensor state

### DIFF
--- a/config/examples/delta/Anycubic/Predator/Configuration.h
+++ b/config/examples/delta/Anycubic/Predator/Configuration.h
@@ -1324,7 +1324,7 @@
   #define FIL_RUNOUT_ENABLED_DEFAULT true // Enable the sensor on startup. Override with M412 followed by M500.
   #define NUM_RUNOUT_SENSORS   1          // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
 
-  #define FIL_RUNOUT_STATE     LOW        // Pin state indicating that filament is NOT present.
+  #define FIL_RUNOUT_STATE     HIGH       // Pin state indicating that filament is NOT present.
   #define FIL_RUNOUT_PULLUP               // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN           // Use internal pulldown for filament runout pins.
 


### PR DESCRIPTION
### Description
For the AnyCubic Predator (delta) - this changes the FIL_RUNOUT_STATE from LOW to HIGH.

### Benefits
Allows the filament runout sensor to function correctly.  Previously it would trigger a M600 (filament change) as soon as a print was started, because the filament sensor was incorrectly triggered when filament was present.

### Related Issues
I googled the issue and found this confirmation:
https://www.thingiverse.com/groups/anycubic-predator/forums/general/topic:48391
