### PR TITLE
Assume nominal belts/pulleys for Tevo configs

### DIFF
--- a/config/examples/Tevo/Michelangelo/Configuration.h
+++ b/config/examples/Tevo/Michelangelo/Configuration.h
@@ -799,7 +799,7 @@
  * Override with M92
  *                                      X, Y, Z, E0 [, E1[, E2...]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80.165, 80.165, 399.2901, 408 }
+#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 400, 408 }
 
 /**
  * Default Max Feed Rate (mm/s)

--- a/config/examples/Tevo/Nereus/Configuration.h
+++ b/config/examples/Tevo/Nereus/Configuration.h
@@ -799,7 +799,7 @@
  * Override with M92
  *                                      X, Y, Z, E0 [, E1[, E2...]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80.4, 80.4, 400, 370 }
+#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 400, 370 }
 
 /**
  * Default Max Feed Rate (mm/s)

--- a/config/examples/Tevo/Tarantula Pro/Configuration.h
+++ b/config/examples/Tevo/Tarantula Pro/Configuration.h
@@ -799,7 +799,7 @@
  * Override with M92
  *                                      X, Y, Z, E0 [, E1[, E2...]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80.058, 80.058, 399.2901, 408 }
+#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 400, 408 }
 
 /**
  * Default Max Feed Rate (mm/s)

--- a/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration.h
+++ b/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration.h
@@ -799,7 +799,7 @@
  * Override with M92
  *                                      X, Y, Z, E0 [, E1[, E2...]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 79.765, 79.765, 399.2901, 400 }
+#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 400, 400 }
 
 /**
  * Default Max Feed Rate (mm/s)

--- a/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration.h
+++ b/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration.h
@@ -799,7 +799,7 @@
  * Override with M92
  *                                      X, Y, Z, E0 [, E1[, E2...]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 79.765, 79.765, 399.2901, 400 }
+#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 400, 400 }
 
 /**
  * Default Max Feed Rate (mm/s)


### PR DESCRIPTION
### Description

Assume nominal belts/pulleys for Tevo configs.

### Benefits

Standard `DEFAULT_AXIS_STEPS_PER_UNIT` values.

### Related Issues

None. This was mentioned in Marlin's Discord.
