### PR TITLE
Fix BABYSTEP_MULTIPLICATOR_Z on Creality V4 boards

### DIFF
--- a/config/examples/Creality/Ender-3 Pro/CrealityV422/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Pro/CrealityV422/Configuration_adv.h
@@ -1799,7 +1799,7 @@
   //#define BABYSTEP_XY                     // Also enable X/Y Babystepping. Not supported on DELTA!
   #define BABYSTEP_INVERT_Z false           // Change if Z babysteps should go the other way
   //#define BABYSTEP_MILLIMETER_UNITS       // Specify BABYSTEP_MULTIPLICATOR_(XY|Z) in mm instead of micro-steps
-  #define BABYSTEP_MULTIPLICATOR_Z  40       // (steps or mm) Steps or millimeter distance for each Z babystep
+  #define BABYSTEP_MULTIPLICATOR_Z  1       // (steps or mm) Steps or millimeter distance for each Z babystep
   #define BABYSTEP_MULTIPLICATOR_XY 1       // (steps or mm) Steps or millimeter distance for each XY babystep
 
   //#define DOUBLECLICK_FOR_Z_BABYSTEPPING  // Double-click on the Status Screen for Z Babystepping.

--- a/config/examples/Creality/Ender-3 V2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/Configuration_adv.h
@@ -1799,7 +1799,7 @@
   //#define BABYSTEP_XY                     // Also enable X/Y Babystepping. Not supported on DELTA!
   #define BABYSTEP_INVERT_Z false           // Change if Z babysteps should go the other way
   //#define BABYSTEP_MILLIMETER_UNITS       // Specify BABYSTEP_MULTIPLICATOR_(XY|Z) in mm instead of micro-steps
-  #define BABYSTEP_MULTIPLICATOR_Z  40      // (steps or mm) Steps or millimeter distance for each Z babystep
+  #define BABYSTEP_MULTIPLICATOR_Z  1       // (steps or mm) Steps or millimeter distance for each Z babystep
   #define BABYSTEP_MULTIPLICATOR_XY 1       // (steps or mm) Steps or millimeter distance for each XY babystep
 
   //#define DOUBLECLICK_FOR_Z_BABYSTEPPING  // Double-click on the Status Screen for Z Babystepping.


### PR DESCRIPTION


### Requirements

* Creality Ender 3 V2 (`config/examples/Creality/Ender-3 V2`) and/or Pro (with v4.2.2 board, `config/examples/Creality/Ender-3 Pro/CrealityV422`)
* Compare to existing babystepping configs on regular Ender 3 with upgraded v4.2.2 board (`config/examples/Creality/Ender-3/CrealityV422`)

### Description

Ender-3 V2 and Ender-3 Pro/CrealityV422 (BOARD_CREALITY_V4; v4.2.2) have BABYSTEP_MULTIPLICATOR_Z 40 which is far too coarse.  Change this to 1 to match other 4.2.2 boards.

### Benefits

Reduces needlessly coarse babystepping on boards with drivers which can support fine babystepping.

### Related Issues

Closes: MarlinFirmware/Configurations#466
