### PR TITLE
disable SD_DETECT_STATE HIGH on Anycubic/Kossel Linear Plus

### DIFF
--- a/config/examples/delta/Anycubic/Kossel Linear Plus/Configuration_adv.h
+++ b/config/examples/delta/Anycubic/Kossel Linear Plus/Configuration_adv.h
@@ -1294,7 +1294,7 @@
 
   // The standard SD detect circuit reads LOW when media is inserted and HIGH when empty.
   // Enable this option and set to HIGH if your SD cards are incorrectly detected.
-  #define SD_DETECT_STATE HIGH
+  //#define SD_DETECT_STATE HIGH
 
   //#define SD_IGNORE_AT_STARTUP            // Don't mount the SD card when starting up
   //#define SDCARD_READONLY                 // Read-only SD card (to save over 2K of flash)


### PR DESCRIPTION
Anycubic/Kossel Linear Plus + REPRAP_DISCOUNT_SMART_CONTROLLER

### Description

SD_DETECT_STATE is reportedly inverted.  Corrected this

### Benefits

SD card words as expected

### Related Issues
https://github.com/MarlinFirmware/Configurations/issues/501

