### PR TITLE
fix Z_MIN_PROBE_ENDSTOP_INVERTING set true when bltouch is enabled

### DIFF
--- a/config/examples/Creality/CR-10 V2/Configuration.h
+++ b/config/examples/Creality/CR-10 V2/Configuration.h
@@ -818,7 +818,7 @@
 #define I_MAX_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
 #define J_MAX_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
 #define K_MAX_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
-#define Z_MIN_PROBE_ENDSTOP_INVERTING ENABLED(CR10V2_BLTOUCH) // Set to true to invert the logic of the probe.
+#define Z_MIN_PROBE_ENDSTOP_INVERTING false // Set to true to invert the logic of the probe.
 
 /**
  * Stepper Drivers


### PR DESCRIPTION
### Requirements

Enable CR10V2_BLTOUCH in Creality/CR-10 V2/Configuration.h
Missed this one, due to config using custom CR10V2_BLTOUCH define. 

### Description

This incorrectly sets Z_MIN_PROBE_ENDSTOP_INVERTING true
Updated to be false

### Benefits

no #error "BLTOUCH requires Z_MIN_PROBE_ENDSTOP_INVERTING set to false. Please update your Configuration.h file."

### Related Issues
https://github.com/MarlinFirmware/Configurations/pull/518 