### PR TITLE
Creality CR10 V2: BLTouch disabled build fix

### DIFF
--- a/config/examples/Creality/CR-10 V2/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 V2/Configuration_adv.h
@@ -1932,7 +1932,9 @@
  * Repeatedly attempt G29 leveling until it succeeds.
  * Stop after G29_MAX_RETRIES attempts.
  */
-#define G29_RETRY_AND_RECOVER
+#if ENABLED(CR10V2_BLTOUCH)
+  #define G29_RETRY_AND_RECOVER
+#endif
 #if ENABLED(G29_RETRY_AND_RECOVER)
   #define G29_MAX_RETRIES 3
   #define G29_HALT_ON_FAILURE


### PR DESCRIPTION
### Requirements

The BLTouch is an optional upgrade for the  Creality CR10 v2.

Currently the build fails when CR10V2_BLTOUCH is disabled:

"G29_RETRY_AND_RECOVER requires AUTO_BED_LEVELING_3POINT, LINEAR, or BILINEAR."

### Description

Only enable G29_RETRY_AND_RECOVER when CR10V2_BLTOUCH is enabled.

