### PR TITLE
Clarify in Ender 3 v2 that the sdcard have to be formatted

### DIFF
--- a/config/examples/Creality/Ender-3 V2/README.md
+++ b/config/examples/Creality/Ender-3 V2/README.md
@@ -10,8 +10,8 @@ Therefore, to flash the compiled firmware binary onto the board you must give th
 
 To update the graphics and icons on the display:
 
-- Format a sdcard to Fat32 and 4k allocation
-- Copy the `DWIN_SET` folder to an SD card and insert the card into the slot on the back of the display unit.
+- Format an SD card using the FAT32 filesystem with 4K cluster size.
+- Copy the `DWIN_SET` folder to the SD card and insert the card into the slot on the back of the display unit.
 - Power on the machine and wait for the screen to change from blue to orange.
 - Power off the machine.
 - Remove the SD card from the back of the display.

--- a/config/examples/Creality/Ender-3 V2/README.md
+++ b/config/examples/Creality/Ender-3 V2/README.md
@@ -10,6 +10,7 @@ Therefore, to flash the compiled firmware binary onto the board you must give th
 
 To update the graphics and icons on the display:
 
+- Format a sdcard to Fat32 and 4k allocation
 - Copy the `DWIN_SET` folder to an SD card and insert the card into the slot on the back of the display unit.
 - Power on the machine and wait for the screen to change from blue to orange.
 - Power off the machine.

--- a/config/examples/Creality/Ender-5 Plus/README.md
+++ b/config/examples/Creality/Ender-5 Plus/README.md
@@ -8,7 +8,8 @@ NOTE: The Ender-5 LCD stock firmware is only compatible with Creality firmware. 
 
 The Ender-5 stock LCD can optionally use a [customized Marlin DGUS interface](https://github.com/coldtobi/Marlin_DGUS_Resources). With the stock LCD firmware Marlin can only be controlled from a host over USB.
 
-- Copy the `DWIN_SET` folder to a microSD card. The microSD card must be <= 8 GB and formatted with a 4K cluster size.
+- Format an SD card using the FAT32 filesystem with 4K cluster size.
+- Copy the `DWIN_SET` folder to the SD card.
 - Power off the printer and disassemble the front panel to get access to the LCD board.
 - Insert the SD card into the slot on the back of the LCD (not the main SD slot).
 - Power on the printer. The screen will turn blue and display several messages, finishing with "SD Card Process... END!".

--- a/config/examples/Creality/Ender-6/README.md
+++ b/config/examples/Creality/Ender-6/README.md
@@ -22,7 +22,7 @@ NOTE: The factory LCD firmware is only compatible with Creality's firmware. The 
 
 The Ender-6 stock LCD can optionally use a [customized Marlin DGUS interface](https://github.com/coldtobi/Marlin_DGUS_Resources). With the stock LCD firmware Marlin can only be controlled from a host over USB (see first section).
 
-- Copy the `DWIN_SET` folder to a microSD card. The microSD card must be <= 8 GB and formatted with a 4K cluster size.
+- Copy the `DWIN_SET` folder to a microSD card. The microSD card must be smaller than 8 GB and formatted with a 4K cluster size.
 - Power off the printer and disassemble the front panel to get access to the LCD board.
 - Insert the SD card into the slot on the back of the LCD (not the main SD slot).
 - Power on the printer. The screen will turn blue and display several messages, finishing with "SD Card Process... END!".


### PR DESCRIPTION
### Description

Update the ender 3 v2 readme to indicate that to update DWIN_SET they have to format the sdcard and in 4k aloocation

### Benefits

Will make sure that people updating dwin_set would do it correctly and it will work for them

