### PR TITLE
disable BLTOUCH_SET_5V_MODE in Creality / Ender-5 Pro/BigTreeTech SKR Mini E3 2.0 with BLTouch

### DIFF
--- a/config/examples/Creality/Ender-5 Pro/BigTreeTech SKR Mini E3 2.0 with BLTouch/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 Pro/BigTreeTech SKR Mini E3 2.0 with BLTouch/Configuration_adv.h
@@ -809,7 +809,7 @@
    * differs, a mode set eeprom write will be completed at initialization.
    * Use the option below to force an eeprom write to a V3.1 probe regardless.
    */
-  #define BLTOUCH_SET_5V_MODE
+  //#define BLTOUCH_SET_5V_MODE
 
   /**
    * Safety: Activate if connecting a probe with an unknown voltage mode.


### PR DESCRIPTION
### Requirements

CONFIG_EXAMPLES_DIR "Creality/Ender-5 Pro/BigTreeTech SKR Mini E3 2.0 with BLTouch"

### Description

This config enabled BLTOUCH_SET_5V_MODE, but both pins PC2 (z-stop) and PC14 (probe) are NOT 5v tolerant

### Benefits

Doesn't damage the IO pin with 5volts

### Related Issues
https://github.com/MarlinFirmware/Configurations/issues/575