### PR TITLE
Update the thinker se and thinker v2 printer example configurations

### DIFF
--- a/config/examples/Eryone/Thinker SE/Configuration.h
+++ b/config/examples/Eryone/Thinker SE/Configuration.h
@@ -21,7 +21,9 @@
  */
 #pragma once
 
-#define THINKERV2_BLTOUCH  // Enable for an installed BLTOUCH
+//#define THINKERV2_BLTOUCH  // Enable for an installed BLTOUCH
+//#define THINKERV2_FL  //Enable for an installed Filament runout sensor
+//#define THINKERV2_Direct //Enable for Direct drive extruder system
 
 /**
  * Configuration.h
@@ -71,7 +73,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(Dana Olson, BLTouch+Runout)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Dana Olson&Eryone, All in one config)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 /**
@@ -145,10 +147,10 @@
 #endif
 
 // Name displayed in the LCD "Ready" message and Info menu
-#ifdef THINKERV2_BLTOUCH
-  #define CUSTOM_MACHINE_NAME "Thinker SE+"
+#if ANY (THINKERV2_BL, THINKERV2_FL, THINKERV2_Direct)
+    #define CUSTOM_MACHINE_NAME "THINKER SE MOD"
 #else
-  #define CUSTOM_MACHINE_NAME "Thinker SE"
+  #define CUSTOM_MACHINE_NAME "THINKER SE"
 #endif
 
 // Printer's unique ID, used by some programs to differentiate between machines.
@@ -837,7 +839,13 @@
 // Mechanical endstop with COM to ground and NC to Signal uses "false" here (most common setup).
 #define X_MIN_ENDSTOP_INVERTING true  // Set to true to invert the logic of the endstop.
 #define Y_MIN_ENDSTOP_INVERTING true  // Set to true to invert the logic of the endstop.
-#define Z_MIN_ENDSTOP_INVERTING false  // Set to true to invert the logic of the endstop.
+
+#ifdef THINKERV2_BLTOUCH
+  #define Z_MIN_ENDSTOP_INVERTING false  // Set to true to invert the logic of the endstop.
+#else
+  #define Z_MIN_ENDSTOP_INVERTING true  // Set to true to invert the logic of the endstop.
+#endif
+
 #define I_MIN_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
 #define J_MIN_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
 #define K_MIN_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
@@ -940,8 +948,11 @@
  * Override with M203
  *                                      X, Y, Z [, I [, J [, K]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_FEEDRATE          { 300, 300, 35, 25 }
-
+#ifdef THINKERV2_Direct
+  #define DEFAULT_MAX_FEEDRATE          { 200, 200, 35, 100 }
+#else
+  #define DEFAULT_MAX_FEEDRATE          { 300, 300, 35, 25 }
+#endif
 //#define LIMITED_MAX_FR_EDITING        // Limit edit via M203 or LCD to DEFAULT_MAX_FEEDRATE * 2
 #if ENABLED(LIMITED_MAX_FR_EDITING)
   #define MAX_FEEDRATE_EDIT_VALUES    { 600, 600, 10, 50 } // ...or, set your own edit limits
@@ -953,7 +964,11 @@
  * Override with M201
  *                                      X, Y, Z [, I [, J [, K]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_ACCELERATION      { 1500, 1500, 150, 1500 }
+#ifdef THINKERV2_Direct
+  #define DEFAULT_MAX_ACCELERATION      { 1000, 1000, 150, 3000 }
+#else
+  #define DEFAULT_MAX_ACCELERATION      { 1500, 1500, 150, 1500 }
+#endif
 
 //#define LIMITED_MAX_ACCEL_EDITING     // Limit edit via M201 or LCD to DEFAULT_MAX_ACCELERATION * 2
 #if ENABLED(LIMITED_MAX_ACCEL_EDITING)
@@ -968,9 +983,15 @@
  *   M204 R    Retract Acceleration
  *   M204 T    Travel Acceleration
  */
-#define DEFAULT_ACCELERATION          1250   // X, Y, Z and E acceleration for printing moves
-#define DEFAULT_RETRACT_ACCELERATION  1250   // E acceleration for retracts
-#define DEFAULT_TRAVEL_ACCELERATION   1500   // X, Y, Z acceleration for travel (non printing) moves
+#ifdef THINKERV2_Direct
+  #define DEFAULT_ACCELERATION          700   // X, Y, Z and E acceleration for printing moves
+  #define DEFAULT_RETRACT_ACCELERATION  1250   // E acceleration for retracts
+  #define DEFAULT_TRAVEL_ACCELERATION   750   // X, Y, Z acceleration for travel (non printing) moves
+#else
+  #define DEFAULT_ACCELERATION          1250   // X, Y, Z and E acceleration for printing moves
+  #define DEFAULT_RETRACT_ACCELERATION  1250   // E acceleration for retracts
+  #define DEFAULT_TRAVEL_ACCELERATION   1500   // X, Y, Z acceleration for travel (non printing) moves
+#endif
 
 /**
  * Default Jerk limits (mm/s)
@@ -1443,16 +1464,22 @@
  * RAMPS-based boards use SERVO3_PIN for the first runout sensor.
  * For other boards you may need to define FIL_RUNOUT_PIN, FIL_RUNOUT2_PIN, etc.
  */
-#define FILAMENT_RUNOUT_SENSOR
-#if ENABLED(FILAMENT_RUNOUT_SENSOR)
-  #define FIL_RUNOUT_ENABLED_DEFAULT true // Enable the sensor on startup. Override with M412 followed by M500.
-  #define NUM_RUNOUT_SENSORS   1          // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
 
-  #define FIL_RUNOUT_STATE     HIGH       // Pin state indicating that filament is NOT present.
-  #define FIL_RUNOUT_PULLUP               // Use internal pullup for filament runout pins.
+#ifdef THINKERV2_FL
+  #define FILAMENT_RUNOUT_SENSOR
+#else
+  //#define FILAMENT_RUNOUT_SENSOR
+#endif
+  #if ENABLED(FILAMENT_RUNOUT_SENSOR)
+    #define FIL_RUNOUT_ENABLED_DEFAULT true // Enable the sensor on startup. Override with M412 followed by M500.
+    #define NUM_RUNOUT_SENSORS   1          // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
+
+    #define FIL_RUNOUT_STATE     HIGH       // Pin state indicating that filament is NOT present.
+    #define FIL_RUNOUT_PULLUP               // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN           // Use internal pulldown for filament runout pins.
   //#define WATCH_ALL_RUNOUT_SENSORS      // Execute runout script on any triggering sensor, not only for the active extruder.
                                           // This is automatically enabled for MIXING_EXTRUDERs.
+
 
   // Override individually if the runout sensors vary
   //#define FIL_RUNOUT1_STATE LOW

--- a/config/examples/Eryone/Thinker SE/README.md
+++ b/config/examples/Eryone/Thinker SE/README.md
@@ -1,22 +1,23 @@
 ## Eryone Thinker SE
 
  - BLTouch probe
- - TMC2208 (standalone) stepper drivers
  - Filament runout Sensor
+ - TMC2208 (standalone) stepper drivers
 
 ## How to use the config
+
 #### Check the hardware of your printer
- 1. You are using the stock printer, no need to modify the config
- 2. You are using the Filament runout sensor:
-    Enable this line(Delete the "//" to enable it)
-    - //#define THINKERV2_FL  //Enable for an installed Filament runout sensor
- 3. You are using the Bltouch:
-    Enable this line(Delete the "//" to enable it)
-    - //#define THINKERV2_BLTOUCH  // Enable for an installed BLTOUCH
- 4. You are using the direct drive extruder:
-    Enable this line(Delete the "//" to enable it)
-    - //#define THINKERV2_Direct //Enable for Direct drive extruder system
- 5. Can I use all of the mod? The answer is yes. You can use all of them or just a part of them.
- 
+
+1. If you're using the stock printer there's need to modify the config.
+2. If you're using the Filament Runout Sensor:
+  - Enable this line (Remove the "`//`" prefix)<br/>
+    `//#define THINKERV2_FL  // Enable for an installed Filament runout sensor`
+3. You are using the Bltouch:
+  - Enable this line (Remove the "`//`" prefix)<br/>
+    `//#define THINKERV2_BLTOUCH  // Enable for an installed BLTOUCH`
+4. You are using the direct drive extruder:
+  - Enable this line (Remove the "`//`" prefix)<br/>
+    `//#define THINKERV2_Direct // Enable for Direct drive extruder system`
+5. Can I use all of the mods? The answer is yes. You can use all of them or just some of them.
 
 ## Have fun :)

--- a/config/examples/Eryone/Thinker SE/README.md
+++ b/config/examples/Eryone/Thinker SE/README.md
@@ -9,13 +9,13 @@
  1. You are using the stock printer, no need to modify the config
  2. You are using the Filament runout sensor:
     Enable this line(Delete the "//" to enable it)
-    //#define THINKERV2_FL  //Enable for an installed Filament runout sensor
+    - //#define THINKERV2_FL  //Enable for an installed Filament runout sensor
  3. You are using the Bltouch:
     Enable this line(Delete the "//" to enable it)
-    //#define THINKERV2_BLTOUCH  // Enable for an installed BLTOUCH
+    - //#define THINKERV2_BLTOUCH  // Enable for an installed BLTOUCH
  4. You are using the direct drive extruder:
     Enable this line(Delete the "//" to enable it)
-    //#define THINKERV2_Direct //Enable for Direct drive extruder system
+    - //#define THINKERV2_Direct //Enable for Direct drive extruder system
  5. Can I use all of the mod? The answer is yes. You can use all of them or just a part of them.
  
 

--- a/config/examples/Eryone/Thinker V2/Configuration.h
+++ b/config/examples/Eryone/Thinker V2/Configuration.h
@@ -22,6 +22,8 @@
 #pragma once
 
 //#define THINKERV2_BLTOUCH  // Enable for an installed BLTOUCH
+//#define THINKERV2_FL  //Enable for an installed Filament runout sensor
+//#define THINKERV2_Direct //Enable for Direct drive extruder system
 
 /**
  * Configuration.h
@@ -71,7 +73,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Dana Olson&Eryone, All in one config)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 /**
@@ -145,12 +147,11 @@
 #endif
 
 // Name displayed in the LCD "Ready" message and Info menu
-#ifdef THINKERV2_BLTOUCH
-  #define CUSTOM_MACHINE_NAME "Thinker V2_BL"
+#if ANY (THINKERV2_BL, THINKERV2_FL, THINKERV2_Direct)
+    #define CUSTOM_MACHINE_NAME "THINKER V2 MOD"
 #else
-  #define CUSTOM_MACHINE_NAME "Thinker V2"
+  #define CUSTOM_MACHINE_NAME "THINKER V2"
 #endif
-
 // Printer's unique ID, used by some programs to differentiate between machines.
 // Choose your own or use a service like https://www.uuidgenerator.net/version4
 //#define MACHINE_UUID "00000000-0000-0000-0000-000000000000"
@@ -630,7 +631,7 @@
  * heater. If your configuration is significantly different than this and you don't understand
  * the issues involved, don't use bed PID until someone else verifies that your hardware works.
  */
-//#define PIDTEMPBED
+#define PIDTEMPBED  // If your PSU has a reset problem then try to disable it to improve this problem
 
 //#define BED_LIMIT_SWITCHING
 
@@ -837,7 +838,13 @@
 // Mechanical endstop with COM to ground and NC to Signal uses "false" here (most common setup).
 #define X_MIN_ENDSTOP_INVERTING true  // Set to true to invert the logic of the endstop.
 #define Y_MIN_ENDSTOP_INVERTING true  // Set to true to invert the logic of the endstop.
-#define Z_MIN_ENDSTOP_INVERTING true  // Set to true to invert the logic of the endstop.
+
+#ifdef THINKERV2_BLTOUCH
+  #define Z_MIN_ENDSTOP_INVERTING false  // Set to true to invert the logic of the endstop.
+#else
+  #define Z_MIN_ENDSTOP_INVERTING true  // Set to true to invert the logic of the endstop.
+#endif
+
 #define I_MIN_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
 #define J_MIN_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
 #define K_MIN_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
@@ -847,7 +854,7 @@
 #define I_MAX_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
 #define J_MAX_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
 #define K_MAX_ENDSTOP_INVERTING false // Set to true to invert the logic of the endstop.
-#define Z_MIN_PROBE_ENDSTOP_INVERTING DISABLED(THINKERV2_BLTOUCH) // Set to true to invert the logic of the probe.
+#define Z_MIN_PROBE_ENDSTOP_INVERTING false // Set to true to invert the logic of the probe.
 
 /**
  * Stepper Drivers
@@ -940,8 +947,11 @@
  * Override with M203
  *                                      X, Y, Z [, I [, J [, K]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_FEEDRATE          { 300, 300, 35, 25 }
-
+#ifdef THINKERV2_Direct
+  #define DEFAULT_MAX_FEEDRATE          { 200, 200, 35, 100 }
+#else
+  #define DEFAULT_MAX_FEEDRATE          { 300, 300, 35, 25 }
+#endif
 //#define LIMITED_MAX_FR_EDITING        // Limit edit via M203 or LCD to DEFAULT_MAX_FEEDRATE * 2
 #if ENABLED(LIMITED_MAX_FR_EDITING)
   #define MAX_FEEDRATE_EDIT_VALUES    { 600, 600, 10, 50 } // ...or, set your own edit limits
@@ -953,7 +963,11 @@
  * Override with M201
  *                                      X, Y, Z [, I [, J [, K]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_ACCELERATION      { 1500, 1500, 150, 1500 }
+#ifdef THINKERV2_Direct
+  #define DEFAULT_MAX_ACCELERATION      { 1000, 1000, 150, 3000 }
+#else
+  #define DEFAULT_MAX_ACCELERATION      { 1500, 1500, 150, 1500 }
+#endif
 
 //#define LIMITED_MAX_ACCEL_EDITING     // Limit edit via M201 or LCD to DEFAULT_MAX_ACCELERATION * 2
 #if ENABLED(LIMITED_MAX_ACCEL_EDITING)
@@ -968,9 +982,15 @@
  *   M204 R    Retract Acceleration
  *   M204 T    Travel Acceleration
  */
-#define DEFAULT_ACCELERATION          1250   // X, Y, Z and E acceleration for printing moves
-#define DEFAULT_RETRACT_ACCELERATION  1250   // E acceleration for retracts
-#define DEFAULT_TRAVEL_ACCELERATION   1500   // X, Y, Z acceleration for travel (non printing) moves
+#ifdef THINKERV2_Direct
+  #define DEFAULT_ACCELERATION          700   // X, Y, Z and E acceleration for printing moves
+  #define DEFAULT_RETRACT_ACCELERATION  1250   // E acceleration for retracts
+  #define DEFAULT_TRAVEL_ACCELERATION   750   // X, Y, Z acceleration for travel (non printing) moves
+#else
+  #define DEFAULT_ACCELERATION          1250   // X, Y, Z and E acceleration for printing moves
+  #define DEFAULT_RETRACT_ACCELERATION  1250   // E acceleration for retracts
+  #define DEFAULT_TRAVEL_ACCELERATION   1500   // X, Y, Z acceleration for travel (non printing) moves
+#endif
 
 /**
  * Default Jerk limits (mm/s)
@@ -1442,13 +1462,18 @@
  * RAMPS-based boards use SERVO3_PIN for the first runout sensor.
  * For other boards you may need to define FIL_RUNOUT_PIN, FIL_RUNOUT2_PIN, etc.
  */
-//#define FILAMENT_RUNOUT_SENSOR
-#if ENABLED(FILAMENT_RUNOUT_SENSOR)
-  #define FIL_RUNOUT_ENABLED_DEFAULT true // Enable the sensor on startup. Override with M412 followed by M500.
-  #define NUM_RUNOUT_SENSORS   1          // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
 
-  #define FIL_RUNOUT_STATE     HIGH       // Pin state indicating that filament is NOT present.
-  #define FIL_RUNOUT_PULLUP               // Use internal pullup for filament runout pins.
+#ifdef THINKERV2_FL
+  #define FILAMENT_RUNOUT_SENSOR
+#else
+  //#define FILAMENT_RUNOUT_SENSOR
+#endif
+  #if ENABLED(FILAMENT_RUNOUT_SENSOR)
+    #define FIL_RUNOUT_ENABLED_DEFAULT true // Enable the sensor on startup. Override with M412 followed by M500.
+    #define NUM_RUNOUT_SENSORS   1          // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
+
+    #define FIL_RUNOUT_STATE     HIGH       // Pin state indicating that filament is NOT present.
+    #define FIL_RUNOUT_PULLUP               // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN           // Use internal pulldown for filament runout pins.
   //#define WATCH_ALL_RUNOUT_SENSORS      // Execute runout script on any triggering sensor, not only for the active extruder.
                                           // This is automatically enabled for MIXING_EXTRUDERs.

--- a/config/examples/Eryone/Thinker V2/Configuration.h
+++ b/config/examples/Eryone/Thinker V2/Configuration.h
@@ -1468,12 +1468,12 @@
 #else
   //#define FILAMENT_RUNOUT_SENSOR
 #endif
-  #if ENABLED(FILAMENT_RUNOUT_SENSOR)
-    #define FIL_RUNOUT_ENABLED_DEFAULT true // Enable the sensor on startup. Override with M412 followed by M500.
-    #define NUM_RUNOUT_SENSORS   1          // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
+#if ENABLED(FILAMENT_RUNOUT_SENSOR)
+  #define FIL_RUNOUT_ENABLED_DEFAULT true // Enable the sensor on startup. Override with M412 followed by M500.
+  #define NUM_RUNOUT_SENSORS   1          // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
 
-    #define FIL_RUNOUT_STATE     HIGH       // Pin state indicating that filament is NOT present.
-    #define FIL_RUNOUT_PULLUP               // Use internal pullup for filament runout pins.
+  #define FIL_RUNOUT_STATE     HIGH       // Pin state indicating that filament is NOT present.
+  #define FIL_RUNOUT_PULLUP               // Use internal pullup for filament runout pins.
   //#define FIL_RUNOUT_PULLDOWN           // Use internal pulldown for filament runout pins.
   //#define WATCH_ALL_RUNOUT_SENSORS      // Execute runout script on any triggering sensor, not only for the active extruder.
                                           // This is automatically enabled for MIXING_EXTRUDERs.

--- a/config/examples/Eryone/Thinker V2/README.md
+++ b/config/examples/Eryone/Thinker V2/README.md
@@ -8,16 +8,16 @@
  1. You are using the stock printer, no need to modify the config
  2. You are using the Filament runout sensor:
     Enable this line(Delete the "//" to enable it)
-    //#define THINKERV2_FL  //Enable for an installed Filament runout sensor
+    - //#define THINKERV2_FL  //Enable for an installed Filament runout sensor
  3. You are using the Bltouch:
     Enable this line(Delete the "//" to enable it)
-    //#define THINKERV2_BLTOUCH  // Enable for an installed BLTOUCH
+    - //#define THINKERV2_BLTOUCH  // Enable for an installed BLTOUCH
  4. You are using the direct drive extruder:
     Enable this line(Delete the "//" to enable it)
-    //#define THINKERV2_Direct //Enable for Direct drive extruder system
+    - //#define THINKERV2_Direct //Enable for Direct drive extruder system
  5. Can I use all of the mod? The answer is yes. You can use all of them or just a part of them.
  6. If your printer PSU has a reset problem. You can disable the PIDTEMPBED feature
     Disable this line(Add the "//" to disable it)
-    #define PIDTEMPBED  // If your PSU has a reset problem then try to disable it to improve this problem
+    - #define PIDTEMPBED  // If your PSU has a reset problem then try to disable it to improve this problem
 
 ## Have fun :)

--- a/config/examples/Eryone/Thinker V2/README.md
+++ b/config/examples/Eryone/Thinker V2/README.md
@@ -4,20 +4,22 @@
  - Filament runout Sensor
 
 ## How to use the config
+
 #### Check the hardware of your printer
- 1. You are using the stock printer, no need to modify the config
- 2. You are using the Filament runout sensor:
-    Enable this line(Delete the "//" to enable it)
-    - //#define THINKERV2_FL  //Enable for an installed Filament runout sensor
- 3. You are using the Bltouch:
-    Enable this line(Delete the "//" to enable it)
-    - //#define THINKERV2_BLTOUCH  // Enable for an installed BLTOUCH
- 4. You are using the direct drive extruder:
-    Enable this line(Delete the "//" to enable it)
-    - //#define THINKERV2_Direct //Enable for Direct drive extruder system
- 5. Can I use all of the mod? The answer is yes. You can use all of them or just a part of them.
- 6. If your printer PSU has a reset problem. You can disable the PIDTEMPBED feature
-    Disable this line(Add the "//" to disable it)
-    - #define PIDTEMPBED  // If your PSU has a reset problem then try to disable it to improve this problem
+
+1. If you're using the stock printer there's need to modify the config.
+2. If you're using the Filament Runout Sensor:
+  - Enable this line (Remove the "`//`" prefix)<br/>
+    `//#define THINKERV2_FL  // Enable for an installed Filament runout sensor`
+3. You are using the Bltouch:
+  - Enable this line (Remove the "`//`" prefix)<br/>
+    `//#define THINKERV2_BLTOUCH  // Enable for an installed BLTOUCH`
+4. You are using the direct drive extruder:
+  - Enable this line (Remove the "`//`" prefix)<br/>
+    `//#define THINKERV2_Direct // Enable for Direct drive extruder system`
+5. Can I use all of the mods? The answer is yes. You can use all of them or just some of them.
+6. If your printer's PSU has a reset problem you can disable the `PIDTEMPBED` feature:
+  - Disable this line (Prefix with "`//`")<br/>
+    `#define PIDTEMPBED  // If your PSU has a reset problem then try to disable it to improve this problem`
 
 ## Have fun :)

--- a/config/examples/Eryone/Thinker V2/README.md
+++ b/config/examples/Eryone/Thinker V2/README.md
@@ -1,7 +1,6 @@
-## Eryone Thinker SE
+## Eryone Thinker V2
 
  - BLTouch probe
- - TMC2208 (standalone) stepper drivers
  - Filament runout Sensor
 
 ## How to use the config
@@ -17,6 +16,8 @@
     Enable this line(Delete the "//" to enable it)
     //#define THINKERV2_Direct //Enable for Direct drive extruder system
  5. Can I use all of the mod? The answer is yes. You can use all of them or just a part of them.
- 
+ 6. If your printer PSU has a reset problem. You can disable the PIDTEMPBED feature
+    Disable this line(Add the "//" to disable it)
+    #define PIDTEMPBED  // If your PSU has a reset problem then try to disable it to improve this problem
 
 ## Have fun :)


### PR DESCRIPTION
### Requirements
None

### Description
We want to update the example configurations for the Thinker SE and Thinker V2 printer.

### Benefits
1. The stock Thinker SE and Thinker V2 printer don't come with Bltouch.
So we disable it as default. Now it is more friendly for the newcomer and player.
2. We have updated the configurations and it supports bltouch, filament runout sensor, and direct drive extruder system. We have moderately integrated these features. It means the user can choose the feature which they want to use.
3. We have updated the readme.md file of the configurations. The user can understand it
more clear now.
4. For the thinker v2 printer. We have enabled the "PIDTEMPBED" to improve the print quality result.
5. Bltouch requires the "z_min endstop logic to false". But the mechanical endstop logic is "true". So we have improved it and now the printer can work in both situations.

### Related Issues
None
