### PR TITLE
CR-20: Enable BABYSTEP_ZPROBE_OFFSET

### DIFF
--- a/config/examples/Creality/CR-20 Pro/Configuration_adv.h
+++ b/config/examples/Creality/CR-20 Pro/Configuration_adv.h
@@ -1883,10 +1883,10 @@
 
   //#define BABYSTEP_DISPLAY_TOTAL          // Display total babysteps since last G28
 
-  //#define BABYSTEP_ZPROBE_OFFSET          // Combine M851 Z and Babystepping
+  #define BABYSTEP_ZPROBE_OFFSET          // Combine M851 Z and Babystepping
   #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
     //#define BABYSTEP_HOTEND_Z_OFFSET      // For multiple hotends, babystep relative Z offsets
-    //#define BABYSTEP_ZPROBE_GFX_OVERLAY   // Enable graphical overlay on Z-offset editor
+    #define BABYSTEP_ZPROBE_GFX_OVERLAY   // Enable graphical overlay on Z-offset editor
   #endif
 #endif
 


### PR DESCRIPTION
### Description

Enable `BABYSTEP_ZPROBE_OFFSET` for CR-20 Pro config.

<details><summary>Build Stats:</summary>
<p>

Build Size Before:
```prolog
Checking size .pio/build/mega2560/firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [======    ]  59.7% (used 4894 bytes from 8192 bytes)
Flash: [======    ]  57.5% (used 146066 bytes from 253952 bytes)
```

Build Size After:
```prolog
Checking size .pio/build/mega2560/firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [======    ]  59.8% (used 4899 bytes from 8192 bytes)
Flash: [======    ]  57.7% (used 146644 bytes from 253952 bytes)
```

</p>
</details>

### Related Issues

- #591