### PR TITLE
update SDSORT_LIMIT back to 40 in CR-10/CrealityV1/Configuration_adv.h

### DIFF
--- a/config/examples/Creality/CR-10/CrealityV1/Configuration_adv.h
+++ b/config/examples/Creality/CR-10/CrealityV1/Configuration_adv.h
@@ -1433,7 +1433,7 @@
 
   // SD Card Sorting options
   #if ENABLED(SDCARD_SORT_ALPHA)
-    #define SDSORT_LIMIT       256    // Maximum number of sorted items (10-256). Costs 27 bytes each.
+    #define SDSORT_LIMIT       40     // Maximum number of sorted items (10-256). Costs 27 bytes each.
     #define FOLDER_SORTING     -1     // -1=above  0=none  1=below
     #define SDSORT_GCODE       false  // Allow turning sorting on/off with LCD and M34 G-code.
     #define SDSORT_USES_RAM    true   // Pre-allocate a static array for faster pre-sorting.


### PR DESCRIPTION
### Requirements

Use example config from CR-10/CrealityV1

### Description

SDSORT_LIMIT of 256 exceeds available memory in the atmega2560.
Compiled firmware has 189% of ram used
This will not boot.

Set SDSORT_LIMIT back to 40

### Benefits

Firmware will not exceed available ram and will boot.

### Related Issues
Memory issue was noticed by Sound in Marlin Discord