### PR TITLE
Correct breakage of FFCP config post PR 22983

### DIFF
--- a/config/examples/FlashForge/CreatorPro/Configuration_adv.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration_adv.h
@@ -584,8 +584,8 @@
  * Multiple extruders can be assigned to the same pin in which case
  * the fan will turn on when any selected extruder is above the threshold.
  */
-#define E0_AUTO_FAN_PIN EX1_FAN_PIN
-#define E1_AUTO_FAN_PIN EX2_FAN_PIN
+#define E0_AUTO_FAN_PIN 7  // formerly known as EX1_FAN_PIN
+#define E1_AUTO_FAN_PIN 12 // formerly known as EX2_FAN_PIN
 #define E2_AUTO_FAN_PIN -1
 #define E3_AUTO_FAN_PIN -1
 #define E4_AUTO_FAN_PIN -1

--- a/config/examples/FlashForge/CreatorPro/Configuration_adv.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration_adv.h
@@ -584,8 +584,8 @@
  * Multiple extruders can be assigned to the same pin in which case
  * the fan will turn on when any selected extruder is above the threshold.
  */
-#define E0_AUTO_FAN_PIN 7  // formerly known as EX1_FAN_PIN
-#define E1_AUTO_FAN_PIN 12 // formerly known as EX2_FAN_PIN
+#define E0_AUTO_FAN_PIN  7  // (i.e., EX1_FAN_PIN)
+#define E1_AUTO_FAN_PIN 12  // (i.e., EX2_FAN_PIN)
 #define E2_AUTO_FAN_PIN -1
 #define E3_AUTO_FAN_PIN -1
 #define E4_AUTO_FAN_PIN -1


### PR DESCRIPTION
### Description

PR 22983 on the Marlin bugfix-2.0.x repository removed the defines previously assigned to the extruder fan pins. Although this brought the MightyBoard more in line with the behavior of other boards, it breaks the existing configuration file for the FFCP and the generic assignments aren't compatible with the factory-shipped board in this machine.


### Benefits

This commit fixes the break by directly assigning the pins used on the FFCP powered by the Rev. E (and Rev. D) Mightyboard. As such, the configuration files will be compatible with the Marlin repo both prior to and after PR 22983.

