### PR TITLE
Enforce Probing Preheat on B1 SE Plus

### DIFF
--- a/config/examples/BIQU/B1 SE Plus/Configuration.h
+++ b/config/examples/BIQU/B1 SE Plus/Configuration.h
@@ -1291,9 +1291,9 @@
 //#define DELAY_BEFORE_PROBING 200  // (ms) To prevent vibrations from triggering piezo sensors
 
 // Require minimum nozzle and/or bed temperature for probing
-//#define PREHEAT_BEFORE_PROBING
+#define PREHEAT_BEFORE_PROBING
 #if ENABLED(PREHEAT_BEFORE_PROBING)
-  #define PROBING_NOZZLE_TEMP 120   // (°C) Only applies to E0 at this time
+  #define PROBING_NOZZLE_TEMP 145   // (°C) Only applies to E0 at this time
   #define PROBING_BED_TEMP     50
 #endif
 


### PR DESCRIPTION
### Description

Printers with strain gauge-type hotends should have this enabled by default.

### Benefits

Proper homing/leveling can only occur when the nozzle touches the bed. It can't do that with plastic bits stuck to the nozzle.

### Related Issues

None.