### PR TITLE
Update Configuration.h

### DIFF
--- a/config/examples/Alfawise/U20/Configuration.h
+++ b/config/examples/Alfawise/U20/Configuration.h
@@ -182,20 +182,22 @@
 
 // Name displayed in the LCD "Ready" message and Info menu
 //#define CUSTOM_MACHINE_NAME "3D Printer"
+// You must manually pick and uncomment one of the selections below so Autobuild Marlin
+// can display proper custom machine name.
 #if ENABLED(U20)
-  #define CUSTOM_MACHINE_NAME "Alfawise U20"
+//  #define CUSTOM_MACHINE_NAME "Alfawise U20"
 #elif ENABLED(U30)
-  #define CUSTOM_MACHINE_NAME "Alfawise U30"
+//  #define CUSTOM_MACHINE_NAME "Alfawise U30"
 #elif ENABLED(U20_PLUS)
-  #define CUSTOM_MACHINE_NAME "Alfawise U20+"
+//  #define CUSTOM_MACHINE_NAME "Alfawise U20+"
 #elif ENABLED(LK1)
-  #define CUSTOM_MACHINE_NAME "Longer3D LK1"
+//  #define CUSTOM_MACHINE_NAME "Longer3D LK1"
 #elif ENABLED(LK1_PLUS)
-  #define CUSTOM_MACHINE_NAME "Longer3D LK1+"
+//  #define CUSTOM_MACHINE_NAME "Longer3D LK1+"
 #elif ENABLED(LK2)
-  #define CUSTOM_MACHINE_NAME "Longer3D LK2"
+//  #define CUSTOM_MACHINE_NAME "Longer3D LK2"
 #elif ENABLED(LK4)
-  #define CUSTOM_MACHINE_NAME "Longer3D LK4"
+//  #define CUSTOM_MACHINE_NAME "Longer3D LK4"
 #else
   #error "Please specify U20, U20_PLUS, U30, LK1, LK1_PLUS, LK2, or LK4."
 #endif


### PR DESCRIPTION
Fix custom machine name to not be logic based, so ABM can display proper name. 
See ABM issue 51: (https://github.com/MarlinFirmware/AutoBuildMarlin/issues/51)

### Requirements
Autobuild Marlin must be able to display correct custom machine name, and cannot do so because there are currently multiple uncommented options surround by logic, which ABM cannot currently handle and parse. 

### Description

See ABM bug/enhancement #51

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
