### PR TITLE
Re-enable auto fan for hotend

### DIFF
--- a/config/examples/Ultimaker/Ultimaker Original Plus (2.1.1)/Configuration_adv.h
+++ b/config/examples/Ultimaker/Ultimaker Original Plus (2.1.1)/Configuration_adv.h
@@ -609,7 +609,7 @@
  * Multiple extruders can be assigned to the same pin in which case
  * the fan will turn on when any selected extruder is above the threshold.
  */
-#define E0_AUTO_FAN_PIN -1
+//#define E0_AUTO_FAN_PIN -1
 #define E1_AUTO_FAN_PIN -1
 #define E2_AUTO_FAN_PIN -1
 #define E3_AUTO_FAN_PIN -1


### PR DESCRIPTION
### Description

The default configuration disables the auto fan / hotend fan. This causes issues. Commenting out the line here that disables it makes for a working printer again.

### Benefits

You can print PLA without heatcreep clogging the hotend again.

### Related Issues

None filed.
