### PR TITLE
Fix sanity check error for FAN_PIN / SPEAKER timer conflict for Anycubic Chiron config

### DIFF
--- a/config/examples/AnyCubic/Chiron/Configuration.h
+++ b/config/examples/AnyCubic/Chiron/Configuration.h
@@ -2879,7 +2879,7 @@
 // Use software PWM to drive the fan, as for the heaters. This uses a very low frequency
 // which is not as annoying as with the hardware PWM. On the other hand, if this frequency
 // is too low, you should also increment SOFT_PWM_SCALE.
-//#define FAN_SOFT_PWM
+#define FAN_SOFT_PWM
 
 // Incrementing this by 1 will double the software PWM frequency,
 // affecting heaters, and the fan if FAN_SOFT_PWM is enabled.


### PR DESCRIPTION
### Description
Build error using Anycubic Chiron config files.

New sanity check error reported due the TIMER2 conflict.
```
Marlin\src\HAL\AVR\../../inc/../HAL/AVR/inc/SanityCheck.h:39:4: error: 
#error "FAN_PIN 9 Hardware PWM uses Timer 2 which conflicts with Arduino AVR Tone Timer (for SPEAKER)."
#error "Disable SPEAKER or enable FAN_SOFT_PWM."
```