### PR TITLE
Add SPI Stepper Support To Index Rev03

### DIFF
--- a/config/examples/Index/REV_03/Configuration_adv.h
+++ b/config/examples/Index/REV_03/Configuration_adv.h
@@ -2925,7 +2925,7 @@
    * The default SW SPI pins are defined the respective pins files,
    * but you can override or define them here.
    */
-  //#define TMC_USE_SW_SPI
+  #define TMC_USE_SW_SPI
   //#define TMC_SW_MOSI       -1
   //#define TMC_SW_MISO       -1
   //#define TMC_SW_SCK        -1


### PR DESCRIPTION
### Description
This PR is an update to the `Configuration.h` file of the Index/LumenPnP Mobo Rev03 board to permanently enable SW SPI. More information can be found in the corresponding Marlin PR: https://github.com/MarlinFirmware/Marlin/pull/23851
