### PR TITLE
Update Creality / CR-10 V3 /Configuration.h

### DIFF
--- a/config/examples/Creality/CR-10 V3/Configuration.h
+++ b/config/examples/Creality/CR-10 V3/Configuration.h
@@ -1604,7 +1604,7 @@
 
   #define FIL_RUNOUT_STATE     LOW        // Pin state indicating that filament is NOT present.
   //#define FIL_RUNOUT_PULLUP               // Use internal pullup for filament runout pins.
-  #define FIL_RUNOUT_PULLDOWN           // Use internal pulldown for filament runout pins.
+  //#define FIL_RUNOUT_PULLDOWN           // Use internal pulldown for filament runout pins.
   //#define WATCH_ALL_RUNOUT_SENSORS      // Execute runout script on any triggering sensor, not only for the active extruder.
                                           // This is automatically enabled for MIXING_EXTRUDERs.
 


### PR DESCRIPTION
Disable FIL_RUNOUT_PULLDOWN as this is an AVR based controller and does not support software enabled pulldowns

This now triggers #error "PULLDOWN pin mode is not available on AVR boards."


