### PR TITLE
Update Index J Stepper Driver Config

### DIFF
--- a/config/examples/Index/REV_03/Configuration_adv.h
+++ b/config/examples/Index/REV_03/Configuration_adv.h
@@ -2866,9 +2866,9 @@
   #endif
 
   #if AXIS_IS_TMC(J)
-    #define J_CURRENT      800
+    #define J_CURRENT      700
     #define J_CURRENT_HOME J_CURRENT
-    #define J_MICROSTEPS    16
+    #define J_MICROSTEPS    8
     #define J_RSENSE         0.11
     #define J_CHAIN_POS     -1
     //#define J_INTERPOLATE  true


### PR DESCRIPTION
### Description

This change will set the J stepper motor driver to the same settings as the I stepper motor driver. Both of these drivers are used to control the PnP heads and should have the same values. 

### Benefits

- Configures both the A and B axis drivers to have the same current and micro step values.
- Fixes the issue where the B axis rotates half as much as the A axis when given the same command.
- Avoids confusion when individual users try to upgrade their machines to have two PnP heads

