### PR TITLE
Enable CR10S Onboard SD Card Reader

### DIFF
--- a/config/examples/Creality/CR-10S/CrealityV1/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/CrealityV1/Configuration_adv.h
@@ -1649,7 +1649,7 @@
    *
    * :[ 'LCD', 'ONBOARD', 'CUSTOM_CABLE' ]
    */
-  //#define SDCARD_CONNECTION LCD
+  #define SDCARD_CONNECTION ONBOARD
 
   // Enable if SD detect is rendered useless (e.g., by using an SD extender)
   //#define NO_SD_DETECT


### PR DESCRIPTION
### Description

Enable CR10S onboard SD card reader.

### Benefits

Onboard SD card reader works again.

### Related Issues

- https://github.com/MarlinFirmware/Configurations/issues/402
