### PR TITLE
Enable Sunlu S8 Auto Fan

### DIFF
--- a/config/examples/Sunlu/S8/Configuration_adv.h
+++ b/config/examples/Sunlu/S8/Configuration_adv.h
@@ -613,7 +613,7 @@
  * Multiple extruders can be assigned to the same pin in which case
  * the fan will turn on when any selected extruder is above the threshold.
  */
-#define E0_AUTO_FAN_PIN -1
+#define E0_AUTO_FAN_PIN  7
 #define E1_AUTO_FAN_PIN -1
 #define E2_AUTO_FAN_PIN -1
 #define E3_AUTO_FAN_PIN -1


### PR DESCRIPTION
### Description

Enable Sunlu S8 auto fan.

The config really needs a new motherboard added to Marlin (as `SH_2560_A4988_V1`) instead of using the generic RAMPS motherboard define, but this will work for now:

<img src="https://user-images.githubusercontent.com/4269371/164109848-e45502f6-686c-4c70-a224-76bf3b5f7136.jpg" width="50%">

### Benefits

Auto fan will work.

### Related Issues

- #713