### PR TITLE
Disable ADAPTIVE_STEP_SMOOTHING on Ender-3 V2 w/ SKR Mini E3 V3

### DIFF
--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 v3/CrealityUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 v3/CrealityUI/Configuration_adv.h
@@ -1203,7 +1203,7 @@
  * vibration and surface artifacts. The algorithm adapts to provide the best possible step smoothing at the
  * lowest stepping frequencies.
  */
-#define ADAPTIVE_STEP_SMOOTHING
+//#define ADAPTIVE_STEP_SMOOTHING
 
 /**
  * Custom Microstepping

--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 v3/MarlinUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 v3/MarlinUI/Configuration_adv.h
@@ -1203,7 +1203,7 @@
  * vibration and surface artifacts. The algorithm adapts to provide the best possible step smoothing at the
  * lowest stepping frequencies.
  */
-#define ADAPTIVE_STEP_SMOOTHING
+//#define ADAPTIVE_STEP_SMOOTHING
 
 /**
  * Custom Microstepping


### PR DESCRIPTION
### Description

Disable `ADAPTIVE_STEP_SMOOTHING` on Ender-3 V2 configs with an SKR Mini E3 V3 since it can cause issues with bed leveling (https://github.com/MarlinFirmware/Marlin/issues/23958)

### Benefits

Bed leveling will work correctly.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/23958
