### PR TITLE
Explicitly specify the number of M106 fan(s)

### DIFF
--- a/config/examples/Dagoma/Disco Ultimate/Configuration.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration.h
@@ -2977,7 +2977,7 @@
 
 // Set number of user-controlled fans. Disable to use all board-defined fans.
 // :[1,2,3,4,5,6,7,8]
-//#define NUM_M106_FANS 1
+#define NUM_M106_FANS 1
 
 // Use software PWM to drive the fan, as for the heaters. This uses a very low frequency
 // which is not as annoying as with the hardware PWM. On the other hand, if this frequency


### PR DESCRIPTION
### Description

The Dagoma DiscoUltimate printer default configuration has only one manual fan and no heating bed.
The default FET_ORDER is consequently set to [EFF](https://github.com/MarlinFirmware/Marlin/blob/c1d3e4634cf3dd9c922b7a3c2a2f981b557d356a/Marlin/src/pins/pins.h#L60).

It leads to [two ventilation management rows on the screen](https://github.com/MarlinFirmware/Marlin/blob/c1d3e4634cf3dd9c922b7a3c2a2f981b557d356a/Marlin/src/lcd/menu/menu_configuration.cpp#L334) but it doesn't match the physical configuration (only one manual fan).

That's why the number of M106 fan(s) must be explicitly defined.

### Benefits

Correct display of the ventilation management row (only one, no more two).

### Related Issues

https://github.com/MarlinFirmware/Marlin/pull/24046