### PR TITLE
Fix TINA2 board name

### DIFF
--- a/config/examples/Weedo/Tina2/README.md
+++ b/config/examples/Weedo/Tina2/README.md
@@ -1,8 +1,27 @@
-## Product Version
+## Product version
+
 - TINA2 WIFI: TINA2 standard version with ESP32 WIFI module installed. Support remote control, send files via wifi, and online 3d model library.
 - TINA2 BASIC: TINA2 lite version, without WIFI module and protective shell.
-The examples provided here compile without wifi
 
-## Hardware Version
+Please note the monorpice cadet printer is a rebranded version of these printers and the provided configuration should work.
+
+## Hardware version
+
 - V2: The motherboard version is 62AS. The endstop type is lever limit switch.
 - V3: The motherboard version is 62AS. The endstop type is mushroom head limit switch.
+
+## Adding wifi support using ESP3D
+
+You can add wifi support using [ESP3D](https://github.com/luc-github/ESP3D).  
+Basically connect your own NodeMCU to second serial port of the MCU.  
+See ESP3D wiki for connection diagram.
+
+In Marlin configuration.h set:  
+`#define SERIAL_PORT_2 3`
+
+## Manufacturer wifi support
+
+Examples provided here have not been tested with wifi board from manufacturer.  
+Setting `#define SERIAL_PORT_2 3` in Marlin configuration.h might be enough to work with manufacturer wifi board.
+
+Feedback are welcome.

--- a/config/examples/Weedo/Tina2/V2/Configuration.h
+++ b/config/examples/Weedo/Tina2/V2/Configuration.h
@@ -98,7 +98,7 @@
 
 // Choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_WEEDO_62A_TINA2
+  #define MOTHERBOARD BOARD_WEEDO_62A
 #endif
 
 /**

--- a/config/examples/Weedo/Tina2/V3/Configuration.h
+++ b/config/examples/Weedo/Tina2/V3/Configuration.h
@@ -98,7 +98,7 @@
 
 // Choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_WEEDO_62A_TINA2
+  #define MOTHERBOARD BOARD_WEEDO_62A
 #endif
 
 /**


### PR DESCRIPTION
### Requirements

There has been a renaming in https://github.com/MarlinFirmware/Marlin/pull/23817 but not in https://github.com/MarlinFirmware/Configurations/pull/685

This PR fix the wrong board name leading to impossible build for printer.

Also updated the readme as Wifi with ESP3D has been tested and original printer supports wifi in one of it's configurations.

### Description


### Benefits

Make TINA2 buildable

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
