### PR TITLE
Update LCD_SERIAL_PORT to 2 For Ender 5 plus

### DIFF
--- a/config/examples/Creality/Ender-5 Plus/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/Configuration.h
@@ -2746,7 +2746,7 @@
 #if ENABLED(DGUS_LCD_UI_MKS)
   #define USE_MKS_GREEN_UI
 #endif
-#define LCD_SERIAL_PORT 3
+#define LCD_SERIAL_PORT 2
 
 //
 // CR-6 OEM touch screen. A DWIN display with touch.


### PR DESCRIPTION
Serial Port 3 is not valid, Causes Pin conflicts with D14
From this Config file.
"#define Y_MAX_PIN 14 // Creality connects Y_MAX to Y_MIN(_PIN) motherboard connector"

### Requirements

Ender 5 plus

### Description

Current configuration is not valid. moved  LCD_SERIAL_PORT from 3 to 2

### Benefits

Complies as expected