### PR TITLE
Fix Ender-6 BLTouch Option

### DIFF
--- a/config/examples/Creality/Ender-6/Configuration.h
+++ b/config/examples/Creality/Ender-6/Configuration.h
@@ -24,7 +24,7 @@
 #error "Use the 'bugfix...' or 'release...' configurations matching your Marlin version."
 
 // Enable this option for BLTouch support
-//#define E6_BLTOUCH_PROBE
+//#define E6_USE_BLTOUCH
 
 /**
  * Configuration.h


### PR DESCRIPTION
### Description

Redoing #743 since it was trashed through some force-pushes of the import-2.1.x branch.

Fix Ender-6 BLTouch Option

### Benefits

BLTouch option will work.

### Related Issues

#743
