### PR TITLE
Fix Biqu BX Config

### DIFF
--- a/config/examples/BIQU/BX/Configuration.h
+++ b/config/examples/BIQU/BX/Configuration.h
@@ -2946,7 +2946,7 @@
 //
 // Touch Screen Settings
 //
-#define TOUCH_SCREEN
+//#define TOUCH_SCREEN
 #if ENABLED(TOUCH_SCREEN)
   #define BUTTON_DELAY_EDIT  50 // (ms) Button repeat delay for edit screens
   #define BUTTON_DELAY_MENU 250 // (ms) Button repeat delay for menus

--- a/config/examples/BIQU/BX/Configuration.h
+++ b/config/examples/BIQU/BX/Configuration.h
@@ -109,7 +109,7 @@
  *
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-#define SERIAL_PORT 4
+#define SERIAL_PORT 1
 
 /**
  * Serial Port Baud Rate
@@ -130,7 +130,7 @@
  * Currently Ethernet (-2) is only supported on Teensy 4.1 boards.
  * :[-2, -1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-//#define SERIAL_PORT_2 -1
+#define SERIAL_PORT_2 -1
 //#define BAUDRATE_2 250000   // Enable to override BAUDRATE
 
 /**


### PR DESCRIPTION
### Description

Fix Biqu BX serial ports because:

- Serial port 1 is for the TFT
- Serial port -1 is for the micro usb
- Serial port 4 is for the WiFi header

Also, disable `TOUCH_SCREEN`.

Found while working with @rhapsodyv on https://github.com/MarlinFirmware/Marlin/issues/24353

We'll still need a PR to fix the BX booting issue (hopefully coming soon), but this is also required.

### Benefits

Correct serial ports.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/24353
