### PR TITLE
Fix Biqu BX Serial Ports

### DIFF
--- a/config/examples/BIQU/BX/Configuration.h
+++ b/config/examples/BIQU/BX/Configuration.h
@@ -109,7 +109,7 @@
  *
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-#define SERIAL_PORT 4
+#define SERIAL_PORT -1 // USB
 
 /**
  * Serial Port Baud Rate
@@ -130,7 +130,7 @@
  * Currently Ethernet (-2) is only supported on Teensy 4.1 boards.
  * :[-2, -1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-//#define SERIAL_PORT_2 -1
+#define SERIAL_PORT_2 1 // TFT
 //#define BAUDRATE_2 250000   // Enable to override BAUDRATE
 
 /**
@@ -138,7 +138,7 @@
  * Currently only supported for AVR, DUE, LPC1768/9 and STM32/STM32F1
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-//#define SERIAL_PORT_3 1
+#define SERIAL_PORT_3 4 // WiFi
 //#define BAUDRATE_3 250000   // Enable to override BAUDRATE
 
 // Enable the Bluetooth serial interface on AT90USB devices


### PR DESCRIPTION
### Description

Fix Biqu BX serial ports because:

- Serial port -1 is for the micro usb
- Serial port 1 is for the TFT
- Serial port 4 is for the WiFi header

See https://github.com/MarlinFirmware/Marlin/pull/24383 for the `TOUCH_SCREEN` patch to stop bootloops / lockups.