### PR TITLE
Update configs for LumenPnP

### DIFF
--- a/config/default/Configuration_adv.h
+++ b/config/default/Configuration_adv.h
@@ -4321,9 +4321,6 @@
   #define MAX7219_DEBUG_PROFILE       6  // Display the fraction of CPU time spent in profiled code on this LED matrix
                                          // row. By default idle() is profiled so this shows how "idle" the processor is.
                                          // See class CodeProfiler.
-  #define MAX7219_DEBUG_PROFILE       6  // Display the fraction of CPU time spent in profiled code on this LED matrix
-                                         // row. By default idle() is profiled so this shows how "idle" the processor is.
-                                         // See class CodeProfiler.
 #endif
 
 /**

--- a/config/examples/Opulo/Lumen_REV3/Configuration.h
+++ b/config/examples/Opulo/Lumen_REV3/Configuration.h
@@ -1021,7 +1021,7 @@
  * Override with M92
  *                                      X, Y, Z [, I [, J [, K...]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 40, 40, 40, 4.44, 4.44, 40 }
+#define DEFAULT_AXIS_STEPS_PER_UNIT   { 1280, 1280, 40, 4.44, 4.44, 40 }
 
 /**
  * Default Max Feed Rate (linear=mm/s, rotational=°/s)

--- a/config/examples/Opulo/Lumen_REV3/Configuration.h
+++ b/config/examples/Opulo/Lumen_REV3/Configuration.h
@@ -141,11 +141,6 @@
 //#define SERIAL_PORT_3 1
 //#define BAUDRATE_3 250000   // Enable to override BAUDRATE
 
-/**
- * RS485 Hardware serial port definition
- */
-#define RS485_SERIAL_PORT 1
-
 // Enable the Bluetooth serial interface on AT90USB devices
 //#define BLUETOOTH
 
@@ -183,6 +178,9 @@
 #define I_DRIVER_TYPE  TMC2209
 #define J_DRIVER_TYPE  TMC2209
 #define K_DRIVER_TYPE  TMC2209
+//#define U_DRIVER_TYPE  A4988
+//#define V_DRIVER_TYPE  A4988
+//#define W_DRIVER_TYPE  A4988
 //#define E0_DRIVER_TYPE A4988
 //#define E1_DRIVER_TYPE A4988
 //#define E2_DRIVER_TYPE A4988
@@ -1478,7 +1476,7 @@
  */
 //#define Z_IDLE_HEIGHT Z_HOME_POS
 
-//#define Z_HOMING_HEIGHT  31.5      // (mm) Minimal Z height before homing (G28) for Z clearance above the bed, clamps, ...
+//#define Z_HOMING_HEIGHT  4      // (mm) Minimal Z height before homing (G28) for Z clearance above the bed, clamps, ...
                                   // Be sure to have this much clearance over your Z_MAX_POS to prevent grinding.
 
 #define Z_AFTER_HOMING  31.5      // (mm) Height to move to after homing Z
@@ -1820,7 +1818,7 @@
 //#define LCD_BED_TRAMMING
 
 #if ENABLED(LCD_BED_TRAMMING)
-  #define BED_TRAMMING_INSET_LFRB { 30, 30, 30, 30 } // (mm) Left, Front, Right, Back insets
+  #define BED_TRAMMING_INSET_LFRB { 30, 30, 30, 30 }  // (mm) Left, Front, Right, Back insets
   #define BED_TRAMMING_HEIGHT      0.0        // (mm) Z height of nozzle at leveling points
   #define BED_TRAMMING_Z_HOP       4.0        // (mm) Z height of nozzle between leveling points
   //#define BED_TRAMMING_INCLUDE_CENTER       // Move to the center after the last corner

--- a/config/examples/Opulo/Lumen_REV3/Configuration_adv.h
+++ b/config/examples/Opulo/Lumen_REV3/Configuration_adv.h
@@ -2765,7 +2765,7 @@
   #if AXIS_IS_TMC(X)
     #define X_CURRENT       800        // (mA) RMS current. Multiply by 1.414 for peak current.
     #define X_CURRENT_HOME  X_CURRENT  // (mA) RMS current for sensorless homing
-    #define X_MICROSTEPS      8        // 0..256
+    #define X_MICROSTEPS      256      // 0..256
     #define X_RSENSE          0.11
     #define X_CHAIN_POS      -1        // -1..0: Not chained. 1: MCU MOSI connected. 2: Next in chain, ...
     //#define X_INTERPOLATE  true      // Enable to override 'INTERPOLATE' for the X axis
@@ -2785,7 +2785,7 @@
   #if AXIS_IS_TMC(Y)
     #define Y_CURRENT       800
     #define Y_CURRENT_HOME  Y_CURRENT
-    #define Y_MICROSTEPS      8
+    #define Y_MICROSTEPS      256
     #define Y_RSENSE          0.11
     #define Y_CHAIN_POS      -1
     //#define Y_INTERPOLATE  true

--- a/config/examples/Opulo/Lumen_REV3/Configuration_adv.h
+++ b/config/examples/Opulo/Lumen_REV3/Configuration_adv.h
@@ -834,8 +834,8 @@
 
 //#define SENSORLESS_BACKOFF_MM  { 2, 2, 0 }  // (linear=mm, rotational=°) Backoff from endstops before sensorless homing
 
-#define HOMING_BUMP_MM      { 5, 5, 2, 2, 2, 5 }       // (linear=mm, rotational=°) Backoff from endstops after first bump
-#define HOMING_BUMP_DIVISOR { 2, 2, 4, 4, 4, 2 }       // Re-Bump Speed Divisor (Divides the Homing Feedrate)
+#define HOMING_BUMP_MM      { 5, 5, 2, 2, 2, 5 } // (linear=mm, rotational=°) Backoff from endstops after first bump
+#define HOMING_BUMP_DIVISOR { 2, 2, 4, 4, 4, 2 } // Re-Bump Speed Divisor (Divides the Homing Feedrate)
 
 //#define HOMING_BACKOFF_POST_MM { 2, 2, 2 }  // (linear=mm, rotational=°) Backoff from endstops after homing
 
@@ -3980,7 +3980,7 @@
 #define FASTER_GCODE_PARSER
 
 #if ENABLED(FASTER_GCODE_PARSER)
-  #define GCODE_QUOTED_STRINGS  // Support for quoted string parameters
+  #define GCODE_QUOTED_STRINGS    // Support for quoted string parameters
 #endif
 
 // Support for MeatPack G-code compression (https://github.com/scottmudge/OctoPrint-MeatPack)


### PR DESCRIPTION
### Description

* Renames the files from `Index/REV_03` to `Opulo/Lumen_REV3`, since the company & machine have been renamed for legal reasons.
* Changes microstepping resolution to `256` as per https://github.com/opulo-inc/lumenpnp/issues/584.

### Benefits

* Configuration file names now match the company and product nae.
* Higher microstepping resolution allows for more accurate calibration and placement.

### Related Issues

Closes https://github.com/opulo-inc/lumenpnp/issues/584
