### PR TITLE
Drop "Lumen" motherboard name from Opulo config

### DIFF
--- a/config/examples/Opulo/Lumen_REV3/Configuration.h
+++ b/config/examples/Opulo/Lumen_REV3/Configuration.h
@@ -98,7 +98,7 @@
 
 // Choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_OPULO_LUMEN_REV3
+  #define MOTHERBOARD BOARD_OPULO_REV3
 #endif
 
 /**


### PR DESCRIPTION
### Description

"Lumen" is the machine the REV3 motherboard goes into, so it should be dropped. Upstream (Marlin) PR is pending with a full Index => Opulo rename.

⚠️ NEEDS https://github.com/MarlinFirmware/Marlin/pull/24433 ⚠️

### Benefits

Finish renaming of Index => Opulo

### Related Issues

- https://github.com/MarlinFirmware/Marlin/pull/24433
- https://github.com/MarlinFirmware/Configurations/pull/766