### PR TITLE
Fix Prusa MK3/S Start G-code

### DIFF
--- a/config/examples/Prusa/MK3/Configuration.h
+++ b/config/examples/Prusa/MK3/Configuration.h
@@ -1758,7 +1758,7 @@
 #endif
 
 #if EITHER(MIN_SOFTWARE_ENDSTOPS, MAX_SOFTWARE_ENDSTOPS)
-  //#define SOFT_ENDSTOPS_MENU_ITEM  // Enable/Disable software endstops from the LCD
+  #define SOFT_ENDSTOPS_MENU_ITEM  // Enable/Disable software endstops from the LCD
 #endif
 
 /**

--- a/config/examples/Prusa/MK3/README.md
+++ b/config/examples/Prusa/MK3/README.md
@@ -20,7 +20,9 @@ The `W` in Průša's `G28 W ; home all without mesh bed level` default G-code do
 Below are some example start G-code scripts from popular slicers to get you started.
 
 ### PrusaSlicer
-Paste the start G-code block below in the "Custom G-code" section under "Printer Settings". Use the "Custom G-code" section under "Filament Settings" to add the [Linear Advance](https://marlinfw.org/docs/features/lin_advance.html) (`M900 K0.0`) value since it can be saved on a per-filament basis.
+- Set your G-code flavor to "Marlin 2" under "Printer Settings" -> "General" -> "Firmware" -> "G-code flavor".
+- Paste the start G-code block below in the "Custom G-code" section under "Printer Settings".
+- Use the "Custom G-code" section under "Filament Settings" to add the [Linear Advance](https://marlinfw.org/docs/features/lin_advance.html) (`M900 K0.0`) value since it can be saved on a per-filament basis.
 ```gcode
 G90 ; use absolute coordinates
 M83 ; extruder relative mode

--- a/config/examples/Prusa/MK3/README.md
+++ b/config/examples/Prusa/MK3/README.md
@@ -29,7 +29,9 @@ M140 S[first_layer_bed_temperature] ; set bed temp
 M190 S[first_layer_bed_temperature] ; wait for bed temp
 G28 ; home all
 G29 ; mesh bed leveling
+M211 S0 ; Disable software endstops for intro line
 G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area
+M211 S1 ; Enable software endstops
 M104 S[first_layer_temperature] ; set hotend temp
 M109 S[first_layer_temperature] ; wait for hotend temp
 G92 E0.0
@@ -49,7 +51,9 @@ M140 S{material_bed_temperature_layer_0} ; set bed temp
 M190 S{material_bed_temperature_layer_0} ; wait for bed temp
 G28 ; home all
 G29 ; mesh bed leveling
+M211 S0 ; Disable software endstops for intro line
 G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area
+M211 S1 ; Enable software endstops
 M104 S{material_print_temperature_layer_0} ; set hotend temp
 M109 S{material_print_temperature_layer_0} ; wait for hotend temp
 G92 E0.0
@@ -68,7 +72,9 @@ M140 S{temperature_heatbed} ; set bed temp
 M190 S{temperature_heatbed} ; wait for bed temp
 G28 ; home all
 G29 ; mesh bed leveling
+M211 S0 ; Disable software endstops for intro line
 G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area
+M211 S1 ; Enable software endstops
 M104 S{temperature_extruder1} ; set hotend temp
 M109 S{temperature_extruder1} ; wait for hotend temp
 G92 E0.0
@@ -88,7 +94,9 @@ M140 S[bed0_temperature] ; set bed temp
 M190 S[bed0_temperature] ; wait for bed temp
 G28 ; home all
 G29 ; mesh bed leveling
+M211 S0 ; Disable software endstops for intro line
 G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area
+M211 S1 ; Enable software endstops
 M104 S[extruder0_temperature] T0 ; set hotend temp
 M109 S[extruder0_temperature] T0 ; wait for hotend temp
 G92 E0.0

--- a/config/examples/Prusa/MK3S-BigTreeTech-BTT002/README.md
+++ b/config/examples/Prusa/MK3S-BigTreeTech-BTT002/README.md
@@ -35,7 +35,9 @@ M140 S[first_layer_bed_temperature] ; set bed temp
 M190 S[first_layer_bed_temperature] ; wait for bed temp
 G28 ; home all
 G29 ; mesh bed leveling
+M211 S0 ; Disable software endstops for intro line
 G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area
+M211 S1 ; Enable software endstops
 M104 S[first_layer_temperature] ; set hotend temp
 M109 S[first_layer_temperature] ; wait for hotend temp
 G92 E0.0
@@ -55,7 +57,9 @@ M140 S{material_bed_temperature_layer_0} ; set bed temp
 M190 S{material_bed_temperature_layer_0} ; wait for bed temp
 G28 ; home all
 G29 ; mesh bed leveling
+M211 S0 ; Disable software endstops for intro line
 G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area
+M211 S1 ; Enable software endstops
 M104 S{material_print_temperature_layer_0} ; set hotend temp
 M109 S{material_print_temperature_layer_0} ; wait for hotend temp
 G92 E0.0
@@ -74,7 +78,9 @@ M140 S{temperature_heatbed} ; set bed temp
 M190 S{temperature_heatbed} ; wait for bed temp
 G28 ; home all
 G29 ; mesh bed leveling
+M211 S0 ; Disable software endstops for intro line
 G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area
+M211 S1 ; Enable software endstops
 M104 S{temperature_extruder1} ; set hotend temp
 M109 S{temperature_extruder1} ; wait for hotend temp
 G92 E0.0
@@ -94,7 +100,9 @@ M140 S[bed0_temperature] ; set bed temp
 M190 S[bed0_temperature] ; wait for bed temp
 G28 ; home all
 G29 ; mesh bed leveling
+M211 S0 ; Disable software endstops for intro line
 G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area
+M211 S1 ; Enable software endstops
 M104 S[extruder0_temperature] T0 ; set hotend temp
 M109 S[extruder0_temperature] T0 ; wait for hotend temp
 G92 E0.0

--- a/config/examples/Prusa/MK3S-BigTreeTech-BTT002/README.md
+++ b/config/examples/Prusa/MK3S-BigTreeTech-BTT002/README.md
@@ -26,7 +26,9 @@ The `W` in Průša's `G28 W ; home all without mesh bed level` default G-code do
 Below are some example start G-code scripts from popular slicers to get you started.
 
 ### PrusaSlicer
-Paste the start G-code block below in the "Custom G-code" section under "Printer Settings". Use the "Custom G-code" section under "Filament Settings" to add the [Linear Advance](https://marlinfw.org/docs/features/lin_advance.html) (`M900 K0.0`) value since it can be saved on a per-filament basis.
+- Set your G-code flavor to "Marlin 2" under "Printer Settings" -> "General" -> "Firmware" -> "G-code flavor".
+- Paste the start G-code block below in the "Custom G-code" section under "Printer Settings".
+- Use the "Custom G-code" section under "Filament Settings" to add the [Linear Advance](https://marlinfw.org/docs/features/lin_advance.html) (`M900 K0.0`) value since it can be saved on a per-filament basis.
 ```gcode
 G90 ; use absolute coordinates
 M83 ; extruder relative mode


### PR DESCRIPTION
### Description

Temporarily disable software endstops for start G-code script to properly reach prime line area.

### Benefits

Extruder will be able to reach Prusa's default location for prime line in front left corner of bed that is outside the standard print area.

<img src="https://user-images.githubusercontent.com/13375512/179307495-c164e1bb-6abc-49a6-bd60-88eaf20d67e0.png" width="50%">
