### PR TITLE
Microswiss Direct Drive Needs Different Steps/mm

### DIFF
--- a/config/examples/Creality/Ender-5 Pro/CrealityV422/Configuration.h
+++ b/config/examples/Creality/Ender-5 Pro/CrealityV422/Configuration.h
@@ -1146,9 +1146,9 @@
  *                                      X, Y, Z [, I [, J [, K...]]], E0 [, E1[, E2...]]
  */
 #if ENABLED(ENDER5_USE_MICROSWISS)
-  #define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 800, 137.6 }
+  #define DEFAULT_AXIS_STEPS_PER_UNIT { 80, 80, 800, 137.6 }
 #else
-  #define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 800, 93 }
+  #define DEFAULT_AXIS_STEPS_PER_UNIT { 80, 80, 800, 93 }
 #endif
 
 /**

--- a/config/examples/Creality/Ender-5 Pro/CrealityV422/Configuration.h
+++ b/config/examples/Creality/Ender-5 Pro/CrealityV422/Configuration.h
@@ -1145,7 +1145,11 @@
  * Override with M92
  *                                      X, Y, Z [, I [, J [, K...]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 800, 93 }
+#if ENABLED(ENDER5_USE_MICROSWISS)
+  #define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 800, 137.6 }
+#else
+  #define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 800, 93 }
+#endif
 
 /**
  * Default Max Feed Rate (linear=mm/s, rotational=°/s)


### PR DESCRIPTION
### Description

Per, https://github.com/MarlinFirmware/Configurations/pull/759#issuecomment-1172669625 & [Microswiss' own documentation](https://cdn.shopify.com/s/files/1/1210/0176/files/Micro_Swiss_Direct_Drive_Extruder_For_Ender_5_Installation_Instructions.pdf), this direct drive hotend needs different steps/mm than stock.

### Benefits

Correct steps/mm when using this direct drive hotend upgrade.

### Related Issues

https://github.com/MarlinFirmware/Configurations/pull/759#issuecomment-1172669625
