### PR TITLE
Update MK3/S Readmes

### DIFF
--- a/config/examples/Prusa/MK3/README.md
+++ b/config/examples/Prusa/MK3/README.md
@@ -21,8 +21,9 @@ Below are some example start G-code scripts from popular slicers to get you star
 
 ### PrusaSlicer
 - Set your G-code flavor to "Marlin 2" under "Printer Settings" -> "General" -> "Firmware" -> "G-code flavor".
-- Paste the start G-code block below in the "Custom G-code" section under "Printer Settings".
 - Use the "Custom G-code" section under "Filament Settings" to add the [Linear Advance](https://marlinfw.org/docs/features/lin_advance.html) (`M900 K0.0`) value since it can be saved on a per-filament basis.
+- Paste the start G-code block below in the "Custom G-code" section under "Printer Settings".
+
 ```gcode
 G90 ; use absolute coordinates
 M83 ; extruder relative mode
@@ -31,9 +32,7 @@ M140 S[first_layer_bed_temperature] ; set bed temp
 M190 S[first_layer_bed_temperature] ; wait for bed temp
 G28 ; home all
 G29 ; mesh bed leveling
-M211 S0 ; Disable software endstops for intro line
-G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area
-M211 S1 ; Enable software endstops
+G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area for intro line
 M104 S[first_layer_temperature] ; set hotend temp
 M109 S[first_layer_temperature] ; wait for hotend temp
 G92 E0.0
@@ -53,9 +52,7 @@ M140 S{material_bed_temperature_layer_0} ; set bed temp
 M190 S{material_bed_temperature_layer_0} ; wait for bed temp
 G28 ; home all
 G29 ; mesh bed leveling
-M211 S0 ; Disable software endstops for intro line
-G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area
-M211 S1 ; Enable software endstops
+G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area for intro line
 M104 S{material_print_temperature_layer_0} ; set hotend temp
 M109 S{material_print_temperature_layer_0} ; wait for hotend temp
 G92 E0.0
@@ -63,6 +60,7 @@ G1 X60.0 E9.0 F1000.0 ; intro line
 G1 X100.0 E12.5 F1000.0 ; intro line
 G92 E0.0
 ```
+
 ### IdeaMaker
 Paste the start G-code block below in the filament's "Start G-code" section. Add your [Linear Advance](https://marlinfw.org/docs/features/lin_advance.html) (`M900 K0.0`) value in the start G-code block below:
 ```gcode
@@ -74,9 +72,7 @@ M140 S{temperature_heatbed} ; set bed temp
 M190 S{temperature_heatbed} ; wait for bed temp
 G28 ; home all
 G29 ; mesh bed leveling
-M211 S0 ; Disable software endstops for intro line
-G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area
-M211 S1 ; Enable software endstops
+G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area for intro line
 M104 S{temperature_extruder1} ; set hotend temp
 M109 S{temperature_extruder1} ; wait for hotend temp
 G92 E0.0
@@ -96,9 +92,7 @@ M140 S[bed0_temperature] ; set bed temp
 M190 S[bed0_temperature] ; wait for bed temp
 G28 ; home all
 G29 ; mesh bed leveling
-M211 S0 ; Disable software endstops for intro line
-G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area
-M211 S1 ; Enable software endstops
+G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area for intro line
 M104 S[extruder0_temperature] T0 ; set hotend temp
 M109 S[extruder0_temperature] T0 ; wait for hotend temp
 G92 E0.0

--- a/config/examples/Prusa/MK3S-BigTreeTech-BTT002/README.md
+++ b/config/examples/Prusa/MK3S-BigTreeTech-BTT002/README.md
@@ -27,8 +27,9 @@ Below are some example start G-code scripts from popular slicers to get you star
 
 ### PrusaSlicer
 - Set your G-code flavor to "Marlin 2" under "Printer Settings" -> "General" -> "Firmware" -> "G-code flavor".
-- Paste the start G-code block below in the "Custom G-code" section under "Printer Settings".
 - Use the "Custom G-code" section under "Filament Settings" to add the [Linear Advance](https://marlinfw.org/docs/features/lin_advance.html) (`M900 K0.0`) value since it can be saved on a per-filament basis.
+- Paste the start G-code block below in the "Custom G-code" section under "Printer Settings".
+
 ```gcode
 G90 ; use absolute coordinates
 M83 ; extruder relative mode
@@ -37,9 +38,7 @@ M140 S[first_layer_bed_temperature] ; set bed temp
 M190 S[first_layer_bed_temperature] ; wait for bed temp
 G28 ; home all
 G29 ; mesh bed leveling
-M211 S0 ; Disable software endstops for intro line
-G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area
-M211 S1 ; Enable software endstops
+G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area for intro line
 M104 S[first_layer_temperature] ; set hotend temp
 M109 S[first_layer_temperature] ; wait for hotend temp
 G92 E0.0
@@ -59,9 +58,7 @@ M140 S{material_bed_temperature_layer_0} ; set bed temp
 M190 S{material_bed_temperature_layer_0} ; wait for bed temp
 G28 ; home all
 G29 ; mesh bed leveling
-M211 S0 ; Disable software endstops for intro line
-G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area
-M211 S1 ; Enable software endstops
+G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area for intro line
 M104 S{material_print_temperature_layer_0} ; set hotend temp
 M109 S{material_print_temperature_layer_0} ; wait for hotend temp
 G92 E0.0
@@ -69,6 +66,7 @@ G1 X60.0 E9.0 F1000.0 ; intro line
 G1 X100.0 E12.5 F1000.0 ; intro line
 G92 E0.0
 ```
+
 ### IdeaMaker
 Paste the start G-code block below in the filament's "Start G-code" section. Add your [Linear Advance](https://marlinfw.org/docs/features/lin_advance.html) (`M900 K0.0`) value in the start G-code block below:
 ```gcode
@@ -80,9 +78,7 @@ M140 S{temperature_heatbed} ; set bed temp
 M190 S{temperature_heatbed} ; wait for bed temp
 G28 ; home all
 G29 ; mesh bed leveling
-M211 S0 ; Disable software endstops for intro line
-G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area
-M211 S1 ; Enable software endstops
+G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area for intro line
 M104 S{temperature_extruder1} ; set hotend temp
 M109 S{temperature_extruder1} ; wait for hotend temp
 G92 E0.0
@@ -102,9 +98,7 @@ M140 S[bed0_temperature] ; set bed temp
 M190 S[bed0_temperature] ; wait for bed temp
 G28 ; home all
 G29 ; mesh bed leveling
-M211 S0 ; Disable software endstops for intro line
-G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area
-M211 S1 ; Enable software endstops
+G1 X0 Z0.6 Y-3.0 F1000.0 ; go outside print area for intro line
 M104 S[extruder0_temperature] T0 ; set hotend temp
 M109 S[extruder0_temperature] T0 ; wait for hotend temp
 G92 E0.0


### PR DESCRIPTION
### Description

Disabling/Enabling software endstops for intro/purge line are not needed due to properly defined travel limits.

### Benefits

Simplified start g-code.
