### PR TITLE
remove #define SERIAL_PORT_2 3 from Ender-3 Pro CrealityV422

### DIFF
--- a/config/examples/Creality/Ender-3 Pro/CrealityV422/Configuration.h
+++ b/config/examples/Creality/Ender-3 Pro/CrealityV422/Configuration.h
@@ -122,7 +122,7 @@
  * Currently Ethernet (-2) is only supported on Teensy 4.1 boards.
  * :[-2, -1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-#define SERIAL_PORT_2 3
+//#define SERIAL_PORT_2 3
 //#define BAUDRATE_2 250000   // :[2400, 9600, 19200, 38400, 57600, 115200, 250000, 500000, 1000000] Enable to override BAUDRATE
 
 /**


### PR DESCRIPTION
### Description

UART3_TX_PIN  is IO pin  PB10 
The Creality V4.2.2 uses this pin  as #define BTN_EN1                    PB10 

These are in conflict. 

### Benefits

Conflict removed

### Related Issues
Noticed while adding https://github.com/MarlinFirmware/Marlin/pull/24795
also in ender 2 pro https://github.com/MarlinFirmware/Configurations/pull/817