### PR TITLE
Fix Ender-3 with BTT E3 Turbo Z2 Current

### DIFF
--- a/config/examples/Creality/Ender-3/BigTreeTech SKR E3 Turbo/Dual Z/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/BigTreeTech SKR E3 Turbo/Dual Z/Configuration_adv.h
@@ -2868,10 +2868,10 @@
   #endif
 
   #if AXIS_IS_TMC(Z2)
-    #define Z2_CURRENT      800
-    #define Z2_CURRENT_HOME Z2_CURRENT
+    #define Z2_CURRENT       Z_CURRENT
+    #define Z2_CURRENT_HOME  Z_CURRENT_HOME
     #define Z2_MICROSTEPS    Z_MICROSTEPS
-    #define Z2_RSENSE         0.11
+    #define Z2_RSENSE        Z_RSENSE
     #define Z2_CHAIN_POS     -1
     //#define Z2_INTERPOLATE true
     //#define Z2_HOLD_MULTIPLIER 0.5


### PR DESCRIPTION
### Description

Dual Z config with onboard TMC2209s needs matching Z1 & Z2 settings.

I checked the other E3 Turbo-based configs and the only other one with dual z enabled has all motor currents set to 800, so I didn't touch it.

### Benefits

Z1 & Z2 settings will match.

### Related Issues

None. Found while bringing my Ender-3 with E3 Turbo up to date.
