### PR TITLE
Update Simulator Config

### DIFF
--- a/config/examples/Simulator/Configuration.h
+++ b/config/examples/Simulator/Configuration.h
@@ -50,6 +50,7 @@
 // Enable parent LCD based on your selection above
 #if EITHER(TFT_CLASSIC_UI, TFT_COLOR_UI)
   #define TFT_GENERIC
+  #define TOUCH_SCREEN
 #elif ENABLED(LIGHTWEIGHT_UI)
   #define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
 #endif

--- a/config/examples/Simulator/Configuration.h
+++ b/config/examples/Simulator/Configuration.h
@@ -43,6 +43,7 @@
 // Simulator currently supports these displays. Choose one!
 //
 #define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
+//#define REPRAP_DISCOUNT_SMART_CONTROLLER
 //#define LIGHTWEIGHT_UI
 //#define TFT_CLASSIC_UI
 //#define TFT_COLOR_UI


### PR DESCRIPTION
### Description

- Add `#define TOUCH_SCREEN` as part of the Classic / Touch UI TFT build since it will fail with a bunch of `TOUCH_*_PIN` errors without it.
- Add `REPRAP_DISCOUNT_SMART_CONTROLLER` to supported LCD list

<details><summary>Full TOUCH_*_PIN error output:</summary>

```prolog
.pio/libdeps/simulator_macos_debug/MarlinSimUI/src/MarlinSimulator/virtual_printer.cpp: In static member function 'static void VirtualPrinter::build()':
.pio/libdeps/simulator_macos_debug/MarlinSimUI/src/MarlinSimulator/virtual_printer.cpp:86:151: error: 'TOUCH_SCK_PIN' was not declared in this scope; did you mean 'TOUCH_CS_PIN'?
   86 |     root->add_component<ST7796Device>("ST7796Device Display", spi_bus_by_pins<TFT_SCK_PIN, TFT_MOSI_PIN, TFT_MISO_PIN>(), TFT_CS_PIN, spi_bus_by_pins<TOUCH_SCK_PIN, TOUCH_MOSI_PIN, TOUCH_MISO_PIN>(), TOUCH_CS_PIN, TFT_DC_PIN, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, BTN_BACK, KILL_PIN);
      |                                                                                                                                                       ^~~~~~~~~~~~~
      |                                                                                                                                                       TOUCH_CS_PIN
.pio/libdeps/simulator_macos_debug/MarlinSimUI/src/MarlinSimulator/virtual_printer.cpp:86:166: error: 'TOUCH_MOSI_PIN' was not declared in this scope; did you mean 'TOUCH_CS_PIN'?
   86 |     root->add_component<ST7796Device>("ST7796Device Display", spi_bus_by_pins<TFT_SCK_PIN, TFT_MOSI_PIN, TFT_MISO_PIN>(), TFT_CS_PIN, spi_bus_by_pins<TOUCH_SCK_PIN, TOUCH_MOSI_PIN, TOUCH_MISO_PIN>(), TOUCH_CS_PIN, TFT_DC_PIN, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, BTN_BACK, KILL_PIN);
      |                                                                                                                                                                      ^~~~~~~~~~~~~~
      |                                                                                                                                                                      TOUCH_CS_PIN
.pio/libdeps/simulator_macos_debug/MarlinSimUI/src/MarlinSimulator/virtual_printer.cpp:86:182: error: 'TOUCH_MISO_PIN' was not declared in this scope; did you mean 'TOUCH_CS_PIN'?
   86 |     root->add_component<ST7796Device>("ST7796Device Display", spi_bus_by_pins<TFT_SCK_PIN, TFT_MOSI_PIN, TFT_MISO_PIN>(), TFT_CS_PIN, spi_bus_by_pins<TOUCH_SCK_PIN, TOUCH_MOSI_PIN, TOUCH_MISO_PIN>(), TOUCH_CS_PIN, TFT_DC_PIN, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, BTN_BACK, KILL_PIN);
      |                                                                                                                                                                                      ^~~~~~~~~~~~~~
      |                                                                                                                                                                                      TOUCH_CS_PIN
.pio/libdeps/simulator_macos_debug/MarlinSimUI/src/MarlinSimulator/virtual_printer.cpp:86:197: error: no matching function for call to 'spi_bus_by_pins<<expression error>, <expression error>, <expression error> >()'
   86 |     root->add_component<ST7796Device>("ST7796Device Display", spi_bus_by_pins<TFT_SCK_PIN, TFT_MOSI_PIN, TFT_MISO_PIN>(), TFT_CS_PIN, spi_bus_by_pins<TOUCH_SCK_PIN, TOUCH_MOSI_PIN, TOUCH_MISO_PIN>(), TOUCH_CS_PIN, TFT_DC_PIN, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, BTN_BACK, KILL_PIN);
      |                                                                                                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from .pio/libdeps/simulator_macos_debug/MarlinSimUI/src/MarlinSimulator/hardware/ST7796Device.h:9,
                 from .pio/libdeps/simulator_macos_debug/MarlinSimUI/src/MarlinSimulator/virtual_printer.cpp:10:
.pio/libdeps/simulator_macos_debug/MarlinSimUI/src/MarlinSimulator/hardware/bus/spi.h:88:9: note: candidate: 'template<short int CLK, short int MOSI, short int MISO> SpiBus& spi_bus_by_pins()'
   88 | SpiBus& spi_bus_by_pins();
      |         ^~~~~~~~~~~~~~~
.pio/libdeps/simulator_macos_debug/MarlinSimUI/src/MarlinSimulator/hardware/bus/spi.h:88:9: note:   template argument deduction/substitution failed:
.pio/libdeps/simulator_macos_debug/MarlinSimUI/src/MarlinSimulator/virtual_printer.cpp:86:197: error: template argument 1 is invalid
   86 |     root->add_component<ST7796Device>("ST7796Device Display", spi_bus_by_pins<TFT_SCK_PIN, TFT_MOSI_PIN, TFT_MISO_PIN>(), TFT_CS_PIN, spi_bus_by_pins<TOUCH_SCK_PIN, TOUCH_MOSI_PIN, TOUCH_MISO_PIN>(), TOUCH_CS_PIN, TFT_DC_PIN, BEEPER_PIN, BTN_EN1, BTN_EN2, BTN_ENC, BTN_BACK, KILL_PIN);
      |                                                                                                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
compilation terminated due to -fmax-errors=5.
*** [.pio/build/simulator_macos_debug/debug/libd2c/MarlinSimUI/MarlinSimulator/virtual_printer.o] Error 1
```
</details>

### Benefits

Simulator will build out of the box.

### Related Issues

None. Found while setting up a simulator build using this config.
