### PR TITLE
Update Configuration.h for AnyCubic Chiron

### DIFF
--- a/config/examples/AnyCubic/Chiron/Configuration.h
+++ b/config/examples/AnyCubic/Chiron/Configuration.h
@@ -2091,7 +2091,7 @@
 #endif
 
 // Homing speeds (linear=mm/min, rotational=°/min)
-#define HOMING_FEEDRATE_MM_M { (70*60), (70*60), (5*60) }
+#define HOMING_FEEDRATE_MM_M { (35*60), (35*60), (5*60) }
 
 // Validate that endstops are triggered on homing moves
 #define VALIDATE_HOMING_ENDSTOPS


### PR DESCRIPTION
### Description
Too much homing speed in the stock configuration. At this speed, the engine can turn the belt and damage it.

### Benefits
Prevents equipment damage

### Related Issues
None