### PR TITLE
Fix Biqu B1 SE Plus Fan Config

### DIFF
--- a/config/examples/BIQU/B1 SE Plus/Configuration.h
+++ b/config/examples/BIQU/B1 SE Plus/Configuration.h
@@ -3238,7 +3238,7 @@
 
 // Set number of user-controlled fans. Disable to use all board-defined fans.
 // :[1,2,3,4,5,6,7,8]
-//#define NUM_M106_FANS 1
+#define NUM_M106_FANS 1
 
 // Use software PWM to drive the fan, as for the heaters. This uses a very low frequency
 // which is not as annoying as with the hardware PWM. On the other hand, if this frequency

--- a/config/examples/BIQU/B1 SE Plus/Configuration_adv.h
+++ b/config/examples/BIQU/B1 SE Plus/Configuration_adv.h
@@ -535,10 +535,10 @@
  * The fan turns on automatically whenever any driver is enabled and turns
  * off (or reduces to idle speed) shortly after drivers are turned off.
  */
-//#define USE_CONTROLLER_FAN
+#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
-  //#define CONTROLLER_FAN2_PIN -1          // Set a custom pin for second controller fan
+  #define CONTROLLER_FAN_PIN       FAN2_PIN // Set a custom pin for the controller fan
+  #define CONTROLLER_FAN2_PIN      FAN1_PIN // Set a custom pin for second controller fan
   //#define CONTROLLER_FAN_USE_Z_ONLY       // With this option only the Z axis is considered
   //#define CONTROLLER_FAN_IGNORE_Z         // Ignore Z stepper. Useful when stepper timeout is disabled.
   #define CONTROLLERFAN_SPEED_MIN         0 // (0-255) Minimum speed. (If set below this value the fan is turned off.)


### PR DESCRIPTION
### Description

Based on https://github.com/MarlinFirmware/Marlin/pull/24995, enable both Controller fans and limit number of `M106` fans to only those that are connected.

For reference:

`FAN1_PIN` = Controller fan on side of case
`FAN2_PIN` = Controller fan near drivers

### Benefits

Better user experience & automated controller cooling since it was only enabled manually with the current config.