### PR TITLE
Fix SD card detection on BIGTREETECH SKR E3-DIP V1.x

### DIFF
--- a/config/examples/Creality/Ender-3/BigTreeTech SKR E3-DIP V1.1/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/BigTreeTech SKR E3-DIP V1.1/Configuration_adv.h
@@ -1519,7 +1519,7 @@
 
   // The standard SD detect circuit reads LOW when media is inserted and HIGH when empty.
   // Enable this option and set to HIGH if your SD cards are incorrectly detected.
-  #define SD_DETECT_STATE HIGH
+  //#define SD_DETECT_STATE HIGH
 
   //#define SD_IGNORE_AT_STARTUP            // Don't mount the SD card when starting up
   //#define SDCARD_READONLY                 // Read-only SD card (to save over 2K of flash)


### PR DESCRIPTION
### Description

I tested the example config on my Ender 3 with BigTreeTech SKR E3-DIP V1.0 board and I needed to leave this line comment out. With `SD_DETECT_STATE HIGH` enabled, the SD card does not work and the printer shows "SD Init Fail" when I remove the card and "Media Removed" when I insert it.

As far as I can tell v1.1 of the board has no changes in this regard:
> What's new with Board version V1.1:
>
> - Modified the SERVO port (hardware of board -- check PDF)
> - Firmware is compatible for both v1.0 and v1.1

Source: https://github.com/bigtreetech/BIGTREETECH-SKR-E3-DIP-V1.0

This comment https://github.com/MarlinFirmware/Marlin/issues/20952#issuecomment-773668391 seems to confirm that `SD_DETECT_STATE HIGH` should be disabled even on board v1.1.

The change enabling `SD_DETECT_STATE HIGH` was done here and I think that it was a mistake: https://github.com/MarlinFirmware/Configurations/pull/279/commits/5512b138478ed5862694e236b71f422dd41c9987#diff-42021d0476fa94f14d9afaa0290738c3b67857151884b5c715c827d135c02b45R1167

See also the original config from BIGTREETECH's repository: https://github.com/bigtreetech/BIGTREETECH-SKR-E3-DIP-V1.0/blob/c93d0309a42848e0fa27f005e9b2031736be7e61/Firmware/Marlin-2.0.7.2-SKR-E3-DIP/Marlin/Configuration_adv.h#L1171

### Benefits

Fixes SD card on BIGTREETECH SKR E3-DIP V1.x boards when using example Marlin config.