### PR TITLE
Fix Biqu BX ABS Bed Preheat Temperature

### DIFF
--- a/config/examples/BIQU/BX/Configuration.h
+++ b/config/examples/BIQU/BX/Configuration.h
@@ -2255,7 +2255,7 @@
 
 #define PREHEAT_4_LABEL       "ABS"
 #define PREHEAT_4_TEMP_HOTEND 240
-#define PREHEAT_4_TEMP_BED    110
+#define PREHEAT_4_TEMP_BED    100
 #define PREHEAT_4_TEMP_CHAMBER 35
 #define PREHEAT_4_FAN_SPEED     0 // Value from 0 to 255
 


### PR DESCRIPTION
### Description

`BED_MAXTEMP` is capped at 100 (110 - `BED_OVERSHOOT`), so decrease ABS bed preheat to match.