### PR TITLE
add release 2.1.2 to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Pre-tested Configurations for Marlin Firmware. Links below…
 - **Release** branches will apply to most users. Select the branch for your version of Marlin.
   Version|File Tree|Download
   ---|---|---
+  2.1.2|([Browse](//github.com/MarlinFirmware/Configurations/tree/release-2.1.2))|([Download ZIP](//github.com/MarlinFirmware/Configurations/archive/refs/heads/release-2.1.2.zip))
   2.1.1|([Browse](//github.com/MarlinFirmware/Configurations/tree/release-2.1.1))|([Download ZIP](//github.com/MarlinFirmware/Configurations/archive/refs/heads/release-2.1.1.zip))
   2.1|([Browse](//github.com/MarlinFirmware/Configurations/tree/release-2.1))|([Download ZIP](//github.com/MarlinFirmware/Configurations/archive/refs/heads/release-2.1.zip))
   2.0.9.5|([Browse](//github.com/MarlinFirmware/Configurations/tree/release-2.0.9.5))|([Download ZIP](//github.com/MarlinFirmware/Configurations/archive/refs/heads/release-2.0.9.5.zip))


### PR DESCRIPTION
### Description

add release 2.1.2 to the README.md

### Benefits

Users can click on link to download release 2.1.2 config examples 

