### PR TITLE
Change HOMING_FEEDRATE_MM_M

### DIFF
--- a/config/examples/delta/kossel_mini/Configuration.h
+++ b/config/examples/delta/kossel_mini/Configuration.h
@@ -2175,7 +2175,7 @@
 #endif
 
 // Homing speeds (linear=mm/min, rotational=°/min)
-#define HOMING_FEEDRATE_MM_M { (200*60), (200*60), (200*60) }
+#define HOMING_FEEDRATE_MM_M { (60*60), (60*60), (60*60) }
 
 // Validate that endstops are triggered on homing moves
 #define VALIDATE_HOMING_ENDSTOPS


### PR DESCRIPTION
The values provided basically hammerd my endstops. Parts broke. Now much more comfortable speed.

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Changed HOMING_FEEDRADE_MM_M for delta/Kossel mini to much lower values.

### Benefits

Not breaking printer.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
