### PR TITLE
Update LCD type in AnyCubic Mega Zero 2.0 Anycubic V1

### DIFF
--- a/config/examples/AnyCubic/Mega Zero 2.0/Anycubic V1/Configuration.h
+++ b/config/examples/AnyCubic/Mega Zero 2.0/Anycubic V1/Configuration.h
@@ -2799,7 +2799,7 @@
 // RepRapDiscount FULL GRAPHIC Smart Controller
 // https://reprap.org/wiki/RepRapDiscount_Full_Graphic_Smart_Controller
 //
-#define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
+//#define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
 
 //
 // K.3D Full Graphic Smart Controller
@@ -2906,7 +2906,7 @@
 // This is RAMPS-compatible using a single 10-pin connector.
 // (For CR-10 owners who want to replace the Melzi Creality board but retain the display)
 //
-//#define CR10_STOCKDISPLAY
+#define CR10_STOCKDISPLAY
 
 //
 // Ender-2 OEM display, a variant of the MKS_MINI_12864


### PR DESCRIPTION
### Description

has a CR10_STOCKDISPLAY not a REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER

### Benefits

LCD works

### Related Issues

Was noticed on discord with a user attempting to update their stock machine

