### PR TITLE
Fix Artillery Genius Y_BED_SIZE

### DIFF
--- a/config/examples/Artillery/Genius/BLTouch/Configuration.h
+++ b/config/examples/Artillery/Genius/BLTouch/Configuration.h
@@ -1757,7 +1757,7 @@
 
 // The size of the printable area
 #define X_BED_SIZE 220
-#define Y_BED_SIZE 230
+#define Y_BED_SIZE 220
 
 // Travel limits (linear=mm, rotational=°) after homing, corresponding to endstop positions.
 #define X_MIN_POS -2

--- a/config/examples/Artillery/Genius/V1/Configuration.h
+++ b/config/examples/Artillery/Genius/V1/Configuration.h
@@ -1757,7 +1757,7 @@
 
 // The size of the printable area
 #define X_BED_SIZE 220
-#define Y_BED_SIZE 230
+#define Y_BED_SIZE 220
 
 // Travel limits (linear=mm, rotational=°) after homing, corresponding to endstop positions.
 #define X_MIN_POS -2


### PR DESCRIPTION
### Requirements

Artillery Genius

### Description

Changed Y_BED_SIZE value to 220 (previously 230) because the Artillery Genius has a bed size of 220x220.

### Benefits

Correct bed size.