### PR TITLE
Adjust Creality Ender-3 Neo bed position

### DIFF
--- a/config/examples/Creality/Ender-3 Neo/Configuration.h
+++ b/config/examples/Creality/Ender-3 Neo/Configuration.h
@@ -1761,8 +1761,8 @@
 #define Y_BED_SIZE 235
 
 // Travel limits (linear=mm, rotational=°) after homing, corresponding to endstop positions.
-#define X_MIN_POS -27
-#define Y_MIN_POS -11
+#define X_MIN_POS -20
+#define Y_MIN_POS -7
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
 #define Y_MAX_POS Y_BED_SIZE


### PR DESCRIPTION
Adjusted X_MIN_POS and Y_MIN_POS to fit exactly real bed position on standard Ender 3 NEO. With previous values :
- X carriage hits frame on position +235 (max position)
- nozzle is out of bed on Y +235 position (and CRtouch hits bed clip when level).

### Requirements

Adjusting bed position to fit reality.

### Description

X_MIN_POS adjusted to -20 and Y_MIN_POS to -7

### Benefits

X0 Y0 position fits exactily bed's corner.
With previous values CRtouch were hiting bed's clip with 10mm PROBE_MARGIN on fifteenth point.

