### PR TITLE
Corrects the default leveling bed temperature (Ender-3 Neo)

### DIFF
--- a/config/examples/Creality/Ender-3 Neo/Configuration.h
+++ b/config/examples/Creality/Ender-3 Neo/Configuration.h
@@ -1954,7 +1954,7 @@
 #define PREHEAT_BEFORE_LEVELING
 #if ENABLED(PREHEAT_BEFORE_LEVELING)
   #define LEVELING_NOZZLE_TEMP   0   // (°C) Only applies to E0 at this time
-  #define LEVELING_BED_TEMP     150
+  #define LEVELING_BED_TEMP     50
 #endif
 
 /**


### PR DESCRIPTION

### Description

 Corrects the default leveling bed temperature "LEVELING_BED_TEMP" from 150C to 50C in the example configuration for the Ender-3 Neo.

### Benefits

Untested, but presumably would have failed to compile or prevented bed leveling from working, as BED_MAXTEMP is 120C. Should work as expected.

