### PR TITLE
Adds RS485 defines to configuration files for LumenPnP

### DIFF
--- a/config/examples/Opulo/Lumen_REV3/Configuration.h
+++ b/config/examples/Opulo/Lumen_REV3/Configuration.h
@@ -3566,3 +3566,8 @@
 
 // Disable servo with M282 to reduce power consumption, noise, and heat when not in use
 //#define SERVO_DETACH_GCODE
+
+// Support for RS485 control
+// #define RS485_ENABLED
+// #define RS485_BUS_BUFFER_SIZE 128
+// #define RS485_SERIAL_PORT 1

--- a/config/examples/Opulo/Lumen_REV3/Configuration.h
+++ b/config/examples/Opulo/Lumen_REV3/Configuration.h
@@ -117,9 +117,9 @@
  * Select a serial port to communicate with RS485 protocol
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-//#define RS485_SERIAL_PORT 1
+#define RS485_SERIAL_PORT 1
 #ifdef RS485_SERIAL_PORT
-  //#define RS485_BUS_BUFFER_SIZE 128
+  #define RS485_BUS_BUFFER_SIZE 128
 #endif
 
 // Enable the Bluetooth serial interface on AT90USB devices
@@ -3566,8 +3566,3 @@
 
 // Disable servo with M282 to reduce power consumption, noise, and heat when not in use
 //#define SERVO_DETACH_GCODE
-
-// Support for RS485 control
-#define RS485_ENABLED
-#define RS485_BUS_BUFFER_SIZE 128
-#define RS485_SERIAL_PORT 1

--- a/config/examples/Opulo/Lumen_REV3/Configuration.h
+++ b/config/examples/Opulo/Lumen_REV3/Configuration.h
@@ -3568,6 +3568,6 @@
 //#define SERVO_DETACH_GCODE
 
 // Support for RS485 control
-// #define RS485_ENABLED
-// #define RS485_BUS_BUFFER_SIZE 128
-// #define RS485_SERIAL_PORT 1
+#define RS485_ENABLED
+#define RS485_BUS_BUFFER_SIZE 128
+#define RS485_SERIAL_PORT 1

--- a/config/examples/Opulo/Lumen_REV3/Configuration_adv.h
+++ b/config/examples/Opulo/Lumen_REV3/Configuration_adv.h
@@ -3396,7 +3396,7 @@
  * echo:i2c-reply: from:99 bytes:5 data:hello
  */
 
-//#define EXPERIMENTAL_I2CBUS
+#define EXPERIMENTAL_I2CBUS
 #if ENABLED(EXPERIMENTAL_I2CBUS)
   #define I2C_SLAVE_ADDRESS  0  // Set a value from 8 to 127 to act as a slave
 #endif

--- a/config/examples/Opulo/Lumen_REV4/Configuration.h
+++ b/config/examples/Opulo/Lumen_REV4/Configuration.h
@@ -3568,6 +3568,6 @@
 #define SERVO_DETACH_GCODE
 
 // Support for RS485 control
-// #define RS485_ENABLED
-// #define RS485_BUS_BUFFER_SIZE 128
-// #define RS485_SERIAL_PORT 1
+#define RS485_ENABLED
+#define RS485_BUS_BUFFER_SIZE 128
+#define RS485_SERIAL_PORT 1

--- a/config/examples/Opulo/Lumen_REV4/Configuration.h
+++ b/config/examples/Opulo/Lumen_REV4/Configuration.h
@@ -117,9 +117,9 @@
  * Select a serial port to communicate with RS485 protocol
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-//#define RS485_SERIAL_PORT 1
+#define RS485_SERIAL_PORT 1
 #ifdef RS485_SERIAL_PORT
-  //#define RS485_BUS_BUFFER_SIZE 128
+  #define RS485_BUS_BUFFER_SIZE 128
 #endif
 
 // Enable the Bluetooth serial interface on AT90USB devices
@@ -3566,8 +3566,3 @@
 
 // Disable servo with M282 to reduce power consumption, noise, and heat when not in use
 #define SERVO_DETACH_GCODE
-
-// Support for RS485 control
-#define RS485_ENABLED
-#define RS485_BUS_BUFFER_SIZE 128
-#define RS485_SERIAL_PORT 1

--- a/config/examples/Opulo/Lumen_REV4/Configuration.h
+++ b/config/examples/Opulo/Lumen_REV4/Configuration.h
@@ -3566,3 +3566,8 @@
 
 // Disable servo with M282 to reduce power consumption, noise, and heat when not in use
 #define SERVO_DETACH_GCODE
+
+// Support for RS485 control
+// #define RS485_ENABLED
+// #define RS485_BUS_BUFFER_SIZE 128
+// #define RS485_SERIAL_PORT 1


### PR DESCRIPTION
### Description

This PR adds RS485 defines for the Opulo LumenPnP REV03 and REV04 motherboards, used in conjunction with the M485 command in [this PR](https://github.com/MarlinFirmware/Marlin/pull/25680).

### Benefits

This gives LumenPnP motherboards the ability to communicate over the RS485 bus meant for feeder communication. You can read more about feeders [here](https://docs.opulo.io/feeders/1-overview/feeder-overview/).

### Related Issues

No related issues to this PR.
