### PR TITLE
ABS preheat value fixed

### DIFF
--- a/config/examples/Creality/CR-10S/CrealityV1/Configuration.h
+++ b/config/examples/Creality/CR-10S/CrealityV1/Configuration.h
@@ -2356,7 +2356,7 @@
 #define PREHEAT_1_FAN_SPEED     0 // Value from 0 to 255
 
 #define PREHEAT_2_LABEL       "ABS"
-#define PREHEAT_2_TEMP_HOTEND 250
+#define PREHEAT_2_TEMP_HOTEND 210 // ABS working temp between 210 and 250 C.
 #define PREHEAT_2_TEMP_BED    80
 #define PREHEAT_2_TEMP_CHAMBER 35
 #define PREHEAT_2_FAN_SPEED     0 // Value from 0 to 255

--- a/config/examples/Creality/CR-10S/CrealityV1/Configuration.h
+++ b/config/examples/Creality/CR-10S/CrealityV1/Configuration.h
@@ -2356,7 +2356,7 @@
 #define PREHEAT_1_FAN_SPEED     0 // Value from 0 to 255
 
 #define PREHEAT_2_LABEL       "ABS"
-#define PREHEAT_2_TEMP_HOTEND 210 // ABS working temp between 210 and 250 C.
+#define PREHEAT_2_TEMP_HOTEND 235 // ABS working temp between 210 and 250 C.
 #define PREHEAT_2_TEMP_BED    80
 #define PREHEAT_2_TEMP_CHAMBER 35
 #define PREHEAT_2_FAN_SPEED     0 // Value from 0 to 255


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

This PR changes the ABS preheat temperature to avoid the assert causing the following error.

Marlin\src\module\temperature.cpp:335:38: error: static assertion failed: PREHEAT_2_TEMP_HOTEND (245) must be less than HEATER_0_MAXTEMP (250) - 15.

As ABS melts between 210 and 250, 210 is a better preheat temperature anyway.

### Benefits

Current config will not compile in bugfix-2.1.x because of the above assert in temperature.cpp.

### Related Issues
N/A
