### PR TITLE
Fix Ultimaker 2/2+ Encoder Pulses Per Step

### DIFF
--- a/config/examples/Ultimaker/Ultimaker 2+/Configuration.h
+++ b/config/examples/Ultimaker/Ultimaker 2+/Configuration.h
@@ -2630,7 +2630,7 @@
 // This option overrides the default number of encoder pulses needed to
 // produce one step. Should be increased for high-resolution encoders.
 //
-//#define ENCODER_PULSES_PER_STEP 4
+#define ENCODER_PULSES_PER_STEP 2
 
 //
 // Use this option to override the number of step signals required to

--- a/config/examples/Ultimaker/Ultimaker 2/Configuration.h
+++ b/config/examples/Ultimaker/Ultimaker 2/Configuration.h
@@ -2643,7 +2643,7 @@
 // This option overrides the default number of encoder pulses needed to
 // produce one step. Should be increased for high-resolution encoders.
 //
-#define ENCODER_PULSES_PER_STEP 1
+#define ENCODER_PULSES_PER_STEP 2
 
 //
 // Use this option to override the number of step signals required to


### PR DESCRIPTION
### Description

Per https://github.com/MarlinFirmware/Configurations/issues/918, `ENCODER_PULSES_PER_STEP` should be 2, not 1 (or the default which ends up being 5)

### Benefits

Selecting items via the LCD will work as expected.

### Related Issues

- https://github.com/MarlinFirmware/Configurations/issues/918
