### PR TITLE
Restore Anycubic Chiron TFT Serial Port

### DIFF
--- a/config/examples/AnyCubic/Chiron/Configuration.h
+++ b/config/examples/AnyCubic/Chiron/Configuration.h
@@ -3157,6 +3157,7 @@
 // Touch-screen LCD for Anycubic Chiron
 //
 #define ANYCUBIC_LCD_CHIRON
+#define LCD_SERIAL_PORT 3
 
 //
 // Touch-screen LCD for Anycubic i3 Mega


### PR DESCRIPTION
### Description

Restore Anycubic Chiron TFT serial port

Note: An alternative fix was provided by @ellensp in https://github.com/MarlinFirmware/Configurations/issues/921#issuecomment-1509645646 and would need to be added in the main MarlinFirmware repo instead of adding the `LCD_SERIAL_PORT` define to this config:

```DiFF
diff --git a/Marlin/src/inc/Conditionals_LCD.h b/Marlin/src/inc/Conditionals_LCD.h
index 60bc653560..cfb72b6745 100644
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -477,7 +477,7 @@
 #endif
 
 // Aliases for LCD features
-#if !DGUS_UI_IS(NONE) || ENABLED(ANYCUBIC_LCD_VYPER)
+#if !DGUS_UI_IS(NONE) || ENABLED(ANYCUBIC_LCD_VYPER) || ENABLED(ANYCUBIC_LCD_CHIRON)
   #define HAS_DGUS_LCD 1
   #if DGUS_UI_IS(ORIGIN, FYSETC, HIPRECY, MKS)
     #define HAS_DGUS_LCD_CLASSIC 1
```

### Benefits

TFT will work on the Chiron again

### Related Issues

- https://github.com/MarlinFirmware/Configurations/issues/921