### PR TITLE
fix wrong TFT defines

### DIFF
--- a/config/examples/Elegoo/Neptune 2/Configuration.h
+++ b/config/examples/Elegoo/Neptune 2/Configuration.h
@@ -3308,7 +3308,7 @@
 // 480x320, 3.5", FSMC Display From MKS
 // Usually paired with MKS Robin Nano V1.2
 //
-//#define MKS_ROBIN_TFT35
+#define MKS_ROBIN_TFT35
 
 //
 // 480x272, 4.3", FSMC Display From MKS
@@ -3359,19 +3359,19 @@
 //
 // Generic TFT with detailed options
 //
-#define TFT_GENERIC
+// #define TFT_GENERIC
 #if ENABLED(TFT_GENERIC)
   // :[ 'AUTO', 'ST7735', 'ST7789', 'ST7796', 'R61505', 'ILI9328', 'ILI9341', 'ILI9488' ]
-  #define TFT_DRIVER ILI9341
+  //#define TFT_DRIVER AUTO
 
   // Interface. Enable one of the following options:
-  #define TFT_INTERFACE_FSMC
+  //#define TFT_INTERFACE_FSMC
   //#define TFT_INTERFACE_SPI
 
   // TFT Resolution. Enable one of the following options:
   //#define TFT_RES_320x240
   //#define TFT_RES_480x272
-  #define TFT_RES_480x320
+  //#define TFT_RES_480x320
   //#define TFT_RES_1024x600
 #endif
 

--- a/config/examples/Elegoo/Neptune 2/Configuration.h
+++ b/config/examples/Elegoo/Neptune 2/Configuration.h
@@ -3359,7 +3359,7 @@
 //
 // Generic TFT with detailed options
 //
-// #define TFT_GENERIC
+//#define TFT_GENERIC
 #if ENABLED(TFT_GENERIC)
   // :[ 'AUTO', 'ST7735', 'ST7789', 'ST7796', 'R61505', 'ILI9328', 'ILI9341', 'ILI9488' ]
   //#define TFT_DRIVER AUTO


### PR DESCRIPTION
ILI9341 max resolution is 320x240, i don't know how it worked at all... This needs to be backported all the way back to 2.0.9.4