### PR TITLE
BigTreeTech Manta M4P V1.0 => V2.1

### DIFF
--- a/config/examples/BIQU/Hurakan/Configuration.h
+++ b/config/examples/BIQU/Hurakan/Configuration.h
@@ -70,7 +70,7 @@
 
 // Choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_BTT_MANTA_M4P_V1_0
+  #define MOTHERBOARD BOARD_BTT_MANTA_M4P_V2_1
 #endif
 
 /**


### PR DESCRIPTION
### Description

Rename Manta M4P V1.0 to V2.1 since earlier versions were internal only.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/pull/26226
