### PR TITLE
disable G26_MESH_VALIDATION Ender-3 S1 STM32F4

### DIFF
--- a/config/examples/Creality/Ender-3 S1/STM32F4/Configuration.h
+++ b/config/examples/Creality/Ender-3 S1/STM32F4/Configuration.h
@@ -2086,7 +2086,7 @@
   /**
    * Enable the G26 Mesh Validation Pattern tool.
    */
-  #define G26_MESH_VALIDATION
+  //#define G26_MESH_VALIDATION
   #if ENABLED(G26_MESH_VALIDATION)
     #define MESH_TEST_NOZZLE_SIZE    0.4  // (mm) Diameter of primary nozzle.
     #define MESH_TEST_LAYER_HEIGHT   0.2  // (mm) Default layer height for G26.


### PR DESCRIPTION
### Requirements

Creality/Ender-3 S1/STM32F4

### Description

Currently this example config will overflow the flash region.
Something needs to be disabled, 
I'm suggesting it should be G26_MESH_VALIDATION

### Benefits

Firmware will fit in flash

### Related Issues
Was raised on discord in bugs-chat