### PR TITLE
Updated CR-10 Max Configuration.h

### DIFF
--- a/config/examples/Creality/CR-10 Max/Configuration.h
+++ b/config/examples/Creality/CR-10 Max/Configuration.h
@@ -127,7 +127,7 @@
 //#define BLUETOOTH
 
 // Name displayed in the LCD "Ready" message and Info menu
-//#define CUSTOM_MACHINE_NAME "3D Printer"
+#define CUSTOM_MACHINE_NAME "CR-10 Max"
 
 // Printer's unique ID, used by some programs to differentiate between machines.
 // Choose your own or use a service like https://www.uuidgenerator.net/version4
@@ -1346,10 +1346,10 @@
  * The probe replaces the Z-MIN endstop and is used for Z homing.
  * (Automatically enables USE_PROBE_FOR_Z_HOMING.)
  */
-#define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
+//#define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 // Force the use of the probe for Z-axis homing
-//#define USE_PROBE_FOR_Z_HOMING
+#define USE_PROBE_FOR_Z_HOMING
 
 /**
  * Z_MIN_PROBE_PIN
@@ -1364,7 +1364,7 @@
  *    - Normally-closed (NC) also connect to GND.
  *    - Normally-open (NO) also connect to 5V.
  */
-//#define Z_MIN_PROBE_PIN -1
+#define Z_MIN_PROBE_PIN 19
 
 /**
  * Probe Type


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

For some odd reason the CR-10 Max uses pin 19 for the BL Touch sensor pin and not the default Z- endstop pin or Z Probe Pin as defined in the ramps pin file.

Previously used this config and the BL Touch never triggered, explicitly using pin 19 fixed the issue.

I also just changed the machine name to be "CR-10 Max".

Hope this helps, thanks to all the contributors who make Marlin Possible, YOU ROCK! :b


### Benefits

<!-- What does this fix or improve? -->

- Makes BLTouch Probe work on the CR-10 Max
- Makes the printer name "CR-10 Max"

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->

- None as far as I know