### PR TITLE
Set BIBO Values to Factory defaults

### DIFF
--- a/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/config/examples/BIBO/TouchX/default/Configuration.h
@@ -1932,7 +1932,7 @@
   // After a runout is detected, continue printing this length of filament
   // before executing the runout script. Useful for a sensor at the end of
   // a feed tube. Requires 4 bytes SRAM per sensor, plus 4 bytes overhead.
-  //#define FILAMENT_RUNOUT_DISTANCE_MM 25
+  #define FILAMENT_RUNOUT_DISTANCE_MM 180
 
   #ifdef FILAMENT_RUNOUT_DISTANCE_MM
     // Enable this option to use an encoder disc that toggles the runout pin

--- a/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/config/examples/BIBO/TouchX/default/Configuration.h
@@ -1257,11 +1257,11 @@
  * Override with M201
  *                                      X, Y, Z [, I [, J [, K...]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_ACCELERATION      { 1100, 1100, 300, 5000 }
+#define DEFAULT_MAX_ACCELERATION      { 1100, 1100, 100, 5000 }
 
 //#define LIMITED_MAX_ACCEL_EDITING     // Limit edit via M201 or LCD to DEFAULT_MAX_ACCELERATION * 2
 #if ENABLED(LIMITED_MAX_ACCEL_EDITING)
-  #define MAX_ACCEL_EDIT_VALUES       { 6000, 6000, 200, 20000 } // ...or, set your own edit limits
+  #define MAX_ACCEL_EDIT_VALUES       { 6000, 6000, 300, 20000 } // ...or, set your own edit limits
 #endif
 
 /**
@@ -1292,9 +1292,9 @@
  */
 //#define CLASSIC_JERK
 #if ENABLED(CLASSIC_JERK)
-  #define DEFAULT_XJERK  7.0
-  #define DEFAULT_YJERK  7.0
-  #define DEFAULT_ZJERK  0.65
+  #define DEFAULT_XJERK  10.0
+  #define DEFAULT_YJERK  10.0
+  #define DEFAULT_ZJERK  0.3
   //#define DEFAULT_IJERK  0.3
   //#define DEFAULT_JJERK  0.3
   //#define DEFAULT_KJERK  0.3
@@ -1812,7 +1812,7 @@
 #define Z_MIN_POS 0
 #define X_MAX_POS 141
 #define Y_MAX_POS 93
-#define Z_MAX_POS 186
+#define Z_MAX_POS 160
 //#define I_MIN_POS 0
 //#define I_MAX_POS 50
 //#define J_MIN_POS 0

--- a/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/config/examples/BIBO/TouchX/default/Configuration.h
@@ -1292,8 +1292,8 @@
  */
 //#define CLASSIC_JERK
 #if ENABLED(CLASSIC_JERK)
-  #define DEFAULT_XJERK  10.0
-  #define DEFAULT_YJERK  10.0
+  #define DEFAULT_XJERK 10.0
+  #define DEFAULT_YJERK 10.0
   #define DEFAULT_ZJERK  0.3
   //#define DEFAULT_IJERK  0.3
   //#define DEFAULT_JJERK  0.3


### PR DESCRIPTION
### Description

Max Z travel is 160mm not 186mm This could damage the printer if not corrected

Z acceleration should be 100 not 300
Maximum xy Jerk is 10 not 7
Maximum Z jerk is 0.3 not 0.65

Correcting these values to match factory firmware.

Add FILAMENT_RUNOUT_DISTANCE_MM 180

### Benefits
Max Z travel is 160mm not 186mm This could damage the printer or result in faulty prints if not corrected.

implements FILAMENT_RUNOUT_DISTANCE_MM 180 to reduce filament waste.

### Related Issues

Bug fix from code review