### PR TITLE
Enable BLTouch 5V Mode CR-10 Max

### DIFF
--- a/config/examples/Creality/CR-10 Max/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 Max/Configuration_adv.h
@@ -982,7 +982,7 @@
    * differs, a mode set EEPROM write will be completed at initialization.
    * Use the option below to force an EEPROM write to a V3.1 probe regardless.
    */
-  //#define BLTOUCH_SET_5V_MODE
+  #define BLTOUCH_SET_5V_MODE
 
   // Safety: Enable voltage mode settings in the LCD menu.
   //#define BLTOUCH_LCD_VOLTAGE_MENU


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
Apologies for making multiple pull requests, I am finding these little things as I'm tinkering with my CR-10 Max :b

Enabled BLTouch 5V Mode as the CR-10 Max Mainboard (Creality V2.4) supports it by default, without this change the BLTouch works for the most part but ignores the Y offset of the NOZZLE_TO_PROBE_OFFSET option found in the Configuration.h file from my experience.

I contacted Creality for other reasons but ended up getting the CR-10 Max Pinout from them and it explicitly labels the BLTouch voltage pin (red) as being 5V.

Here is the [picture](https://i.imgur.com/Zt0QaZC.png) for reference the labels are in Mandarin so google translate on mobile is a good tool to have :)

### Benefits

<!-- What does this fix or improve? -->

- Allows BLTouch to work as expected

### Related Issues

- N/A as far as I am aware

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
