### PR TITLE
Fix Prusa MK3 (Einsy Rambo) X_RSENSE

### DIFF
--- a/config/examples/Prusa/MK3/Configuration_adv.h
+++ b/config/examples/Prusa/MK3/Configuration_adv.h
@@ -2927,7 +2927,7 @@
     #define X_CURRENT       500        // (mA) RMS current. Multiply by 1.414 for peak current.
     #define X_CURRENT_HOME  230        // (mA) RMS current for sensorless homing
     #define X_MICROSTEPS     16        // 0..256
-    #define X_RSENSE          0.2      // Multiplied x1000 for TMC26X2
+    #define X_RSENSE          0.22     // Multiplied x1000 for TMC26X
     #define X_CHAIN_POS      -1        // -1..0: Not chained. 1: MCU MOSI connected. 2: Next in chain, ...
     //#define X_INTERPOLATE  true      // Enable to override 'INTERPOLATE' for the X axis
     //#define X_HOLD_MULTIPLIER 0.5    // Enable to override 'HOLD_MULTIPLIER' for the X axis


### PR DESCRIPTION
### Description

Fix Prusa MK3 (Einsy Rambo) `X_RSENSE` value. Found while reviewing https://github.com/MarlinFirmware/Marlin/issues/26384.

### Benefits

`X_RSENSE` & comment will now be correct.


### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/26384
