### PR TITLE
Biqu MicroProbe option for Hurakan

### DIFF
--- a/config/examples/BIQU/Hurakan/Configuration.h
+++ b/config/examples/BIQU/Hurakan/Configuration.h
@@ -23,6 +23,8 @@
 #error "Don't build with import-2.1.x configurations!"
 #error "Use the 'bugfix...' or 'release...' configurations matching your Marlin version."
 
+//#define BIQU_MICROPROBE_V1 // Uncomment for Biqu MicroProbe V1, otherwise V2 is assumed
+
 /**
  * Configuration.h
  *
@@ -1175,7 +1177,7 @@
 #define X_MAX_ENDSTOP_HIT_STATE HIGH
 #define Y_MIN_ENDSTOP_HIT_STATE HIGH
 #define Y_MAX_ENDSTOP_HIT_STATE HIGH
-#define Z_MIN_ENDSTOP_HIT_STATE LOW
+#define Z_MIN_ENDSTOP_HIT_STATE HIGH
 #define Z_MAX_ENDSTOP_HIT_STATE HIGH
 #define I_MIN_ENDSTOP_HIT_STATE HIGH
 #define I_MAX_ENDSTOP_HIT_STATE HIGH
@@ -1189,7 +1191,7 @@
 #define V_MAX_ENDSTOP_HIT_STATE HIGH
 #define W_MIN_ENDSTOP_HIT_STATE HIGH
 #define W_MAX_ENDSTOP_HIT_STATE HIGH
-#define Z_MIN_PROBE_ENDSTOP_HIT_STATE HIGH
+#define Z_MIN_PROBE_ENDSTOP_HIT_STATE TERN(BIQU_MICROPROBE_V1, HIGH, LOW)
 
 // Enable this feature if all enabled endstop pins are interrupt-capable.
 // This will remove the need to poll the interrupt pins, saving many CPU cycles.

--- a/config/examples/BIQU/Hurakan/README.md
+++ b/config/examples/BIQU/Hurakan/README.md
@@ -2,6 +2,8 @@
 
 > [!NOTE]
 > Early Hurakan printers have a raised bed power switch, so enable (uncomment) `#define PROBING_MARGIN_BACK` in `Configuration_adv.h` to prevent the hotend from potentially colliding with the switch assembly while probing.
+>
+> Enable (uncomment) `#define BIQU_MICROPROBE_V1` in `Configuration.h` for Biqu MicroProbe V1, otherwise V2 is assumed.
 
 The Biqu Hurakan ships with a BigTreeTech Manta M4P motherboard which includes an integrated BigTreeTech CB1 single board computer running Klipper. See below for instructions on how to update the CB1 to run OctoPrint.
 


### PR DESCRIPTION
### Description

Add a Biqu MicroProbe V1 option since it triggers HIGH vs. the V2 which triggers LOW. I also reverted changes to `Z_MIN_ENDSTOP_HIT_STATE` since the MicroProbe is connected to the dedicated 5-pin "BLTouch" connector and not the "Z-Stop" connector.

### Benefits

Biqu Hurakan config will work for both versions of MicroProbe.
