### PR TITLE
Enable MicroProbe V2 on Hurakan Build, Biqu => BIQU

### DIFF
--- a/config/examples/BIQU/B1 SE Plus/README.md
+++ b/config/examples/BIQU/B1 SE Plus/README.md
@@ -1,3 +1,3 @@
 # BIQU B1 SE Plus (SKR 2) Firmware
 
-Flash drive support is enabled, but jumpers to enable support may not have been installed correctly from the factory. [Follow Biqu's instructions, starting with Step 2](https://github.com/bigtreetech/BIQU-B1-SE-PLUS/blob/master/B1-SE%20fimware/B1-SE-U%20Disk%20Usage%20Tutorial-English.pdf) if flash drive support is not working correctly.
+Flash drive support is enabled, but jumpers to enable support may not have been installed correctly from the factory. [Follow BIQU's instructions, starting with Step 2](https://github.com/bigtreetech/BIQU-B1-SE-PLUS/blob/master/B1-SE%20fimware/B1-SE-U%20Disk%20Usage%20Tutorial-English.pdf) if flash drive support is not working correctly.

--- a/config/examples/BIQU/B1 SE/README.md
+++ b/config/examples/BIQU/B1 SE/README.md
@@ -1,3 +1,3 @@
 # BIQU B1 SE (SKR 2) Firmware
 
-Flash drive support is enabled, but jumpers to enable support may not have been installed correctly from the factory. [Follow Biqu's instructions, starting with Step 2](https://github.com/bigtreetech/BIQU-B1-SE-PLUS/blob/master/B1-SE%20fimware/B1-SE-U%20Disk%20Usage%20Tutorial-English.pdf) if flash drive support is not working correctly.
+Flash drive support is enabled, but jumpers to enable support may not have been installed correctly from the factory. [Follow BIQU's instructions, starting with Step 2](https://github.com/bigtreetech/BIQU-B1-SE-PLUS/blob/master/B1-SE%20fimware/B1-SE-U%20Disk%20Usage%20Tutorial-English.pdf) if flash drive support is not working correctly.

--- a/config/examples/BIQU/B1/README.md
+++ b/config/examples/BIQU/B1/README.md
@@ -2,7 +2,7 @@
 
 In `Configuration.h` enable the `MOTHERBOARD BOARD_BTT_SKR_V1_4` option at the top to specify the BTT SKR V1.4 motherboard, otherwise the V2.0 board will be applied (slightly farther down).
 
-For the SKR V2.0-based config, flash drive support is enabled by default. Jumpers to enable support may not have been installed correctly from the factory, so [follow Biqu's instructions, starting with Step 2](https://github.com/bigtreetech/BIQU-B1-SE-PLUS/blob/master/B1-SE%20fimware/B1-SE-U%20Disk%20Usage%20Tutorial-English.pdf) if flash drive support is not working correctly.
+For the SKR V2.0-based config, flash drive support is enabled by default. Jumpers to enable support may not have been installed correctly from the factory, so [follow BIQU's instructions, starting with Step 2](https://github.com/bigtreetech/BIQU-B1-SE-PLUS/blob/master/B1-SE%20fimware/B1-SE-U%20Disk%20Usage%20Tutorial-English.pdf) if flash drive support is not working correctly.
 
 ## BLTouch Probe Support
 

--- a/config/examples/BIQU/BX/README.md
+++ b/config/examples/BIQU/BX/README.md
@@ -1,4 +1,4 @@
-# Biqu BX Configuration
+# BIQU BX Configuration
 
 In `Configuration.h` enable the `MOTHERBOARD BOARD_BTT_SKR_SE_BX_V3` option at the top to specify the BTT SKR SE BX V3.0 motherboard, otherwise the V2.0 board will be applied (slightly farther down).
 

--- a/config/examples/BIQU/Hurakan/Configuration.h
+++ b/config/examples/BIQU/Hurakan/Configuration.h
@@ -23,8 +23,6 @@
 #error "Don't build with import-2.1.x configurations!"
 #error "Use the 'bugfix...' or 'release...' configurations matching your Marlin version."
 
-//#define BIQU_MICROPROBE_V1 // Uncomment for Biqu MicroProbe V1, otherwise V2 is assumed
-
 /**
  * Configuration.h
  *
@@ -1192,7 +1190,7 @@
 #define V_MAX_ENDSTOP_HIT_STATE HIGH
 #define W_MIN_ENDSTOP_HIT_STATE HIGH
 #define W_MAX_ENDSTOP_HIT_STATE HIGH
-#define Z_MIN_PROBE_ENDSTOP_HIT_STATE TERN(BIQU_MICROPROBE_V1, HIGH, LOW)
+#define Z_MIN_PROBE_ENDSTOP_HIT_STATE LOW
 
 // Enable this feature if all enabled endstop pins are interrupt-capable.
 // This will remove the need to poll the interrupt pins, saving many CPU cycles.
@@ -1394,7 +1392,7 @@
  * A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
  *   (e.g., an inductive probe or a nozzle-based probe-switch.)
  */
-#define FIX_MOUNTED_PROBE
+//#define FIX_MOUNTED_PROBE
 
 /**
  * Use the nozzle as the probe, as with a conductive
@@ -1467,7 +1465,7 @@
  * Also requires: PROBE_ENABLE_DISABLE
  */
 //#define BIQU_MICROPROBE_V1  // Triggers HIGH
-//#define BIQU_MICROPROBE_V2  // Triggers LOW
+#define BIQU_MICROPROBE_V2    // Triggers LOW
 
 // A probe that is deployed and stowed with a solenoid pin (SOL1_PIN)
 //#define SOLENOID_PROBE

--- a/config/examples/BIQU/Hurakan/README.md
+++ b/config/examples/BIQU/Hurakan/README.md
@@ -1,11 +1,11 @@
-# Biqu Hurakan Configuration
+# BIQU Hurakan Configuration
 
 > [!NOTE]
 > Early Hurakan printers have a raised bed power switch, so enable (uncomment) `#define PROBING_MARGIN_BACK` in `Configuration_adv.h` to prevent the hotend from potentially colliding with the switch assembly while probing.
 >
 > MicroProbe V2 is assumed.
 
-The Biqu Hurakan ships with a BigTreeTech Manta M4P motherboard which includes an integrated BigTreeTech CB1 single board computer running Klipper. See below for instructions on how to update the CB1 to run OctoPrint.
+The BIQU Hurakan ships with a BigTreeTech Manta M4P motherboard which includes an integrated BigTreeTech CB1 single board computer running Klipper. See below for instructions on how to update the CB1 to run OctoPrint.
 
 # Table of Contents
 

--- a/config/examples/BIQU/Hurakan/README.md
+++ b/config/examples/BIQU/Hurakan/README.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > Early Hurakan printers have a raised bed power switch, so enable (uncomment) `#define PROBING_MARGIN_BACK` in `Configuration_adv.h` to prevent the hotend from potentially colliding with the switch assembly while probing.
 >
-> Enable (uncomment) `#define BIQU_MICROPROBE_V1` in `Configuration.h` for Biqu MicroProbe V1, otherwise V2 is assumed.
+> MicroProbe V2 is assumed.
 
 The Biqu Hurakan ships with a BigTreeTech Manta M4P motherboard which includes an integrated BigTreeTech CB1 single board computer running Klipper. See below for instructions on how to update the CB1 to run OctoPrint.
 

--- a/config/examples/BIQU/Thunder Standard/Configuration.h
+++ b/config/examples/BIQU/Thunder Standard/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(thisiskeithb, Biqu Thunder Standard)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(thisiskeithb)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine


### PR DESCRIPTION
### Description

- Follow up to 3855870. Now that we have MicroProbe options, enable MicroProbe V2 & cleanup readme.
- Biqu => BIQU

### Related Issues

- 3855870
- https://github.com/MarlinFirmware/Marlin/pull/26527
