### PR TITLE
🔧 BIQU BX updates

### DIFF
--- a/config/examples/BIQU/BX/Configuration.h
+++ b/config/examples/BIQU/BX/Configuration.h
@@ -3469,7 +3469,7 @@
 
   //#define DISABLE_ENCODER         // Disable the click encoder, if any
 
-  #define TOUCH_SCREEN_CALIBRATION
+  //#define TOUCH_SCREEN_CALIBRATION
 
   //#define TOUCH_CALIBRATION_X 12316
   //#define TOUCH_CALIBRATION_Y -8981

--- a/config/examples/BIQU/BX/Configuration.h
+++ b/config/examples/BIQU/BX/Configuration.h
@@ -3511,7 +3511,7 @@
 // Use software PWM to drive the fan, as for the heaters. This uses a very low frequency
 // which is not as annoying as with the hardware PWM. On the other hand, if this frequency
 // is too low, you should also increment SOFT_PWM_SCALE.
-//#define FAN_SOFT_PWM
+#define FAN_SOFT_PWM
 
 // Incrementing this by 1 will double the software PWM frequency,
 // affecting heaters, and the fan if FAN_SOFT_PWM is enabled.

--- a/config/examples/BIQU/BX/Configuration_adv.h
+++ b/config/examples/BIQU/BX/Configuration_adv.h
@@ -602,7 +602,7 @@
  * gets it spinning reliably for a short time before setting the requested speed.
  * (Does not work on Sanguinololu with FAN_SOFT_PWM.)
  */
-//#define FAN_KICKSTART_TIME  100  // (ms)
+#define FAN_KICKSTART_TIME    100  // (ms)
 //#define FAN_KICKSTART_POWER 180  // 64-255
 
 // Some coolers may require a non-zero "off" state.
@@ -620,7 +620,7 @@
  *
  * Define one or both of these to override the default 0-255 range.
  */
-//#define FAN_MIN_PWM 50
+#define FAN_MIN_PWM   26
 //#define FAN_MAX_PWM 128
 
 /**

--- a/config/examples/BIQU/BX/Configuration_adv.h
+++ b/config/examples/BIQU/BX/Configuration_adv.h
@@ -3343,7 +3343,7 @@
   //#define CHOPPER_TIMING_U  CHOPPER_TIMING        // For U Axis
   //#define CHOPPER_TIMING_V  CHOPPER_TIMING        // For V Axis
   //#define CHOPPER_TIMING_W  CHOPPER_TIMING        // For W Axis
-  //#define CHOPPER_TIMING_E  CHOPPER_TIMING        // For Extruders (override below)
+  #define CHOPPER_TIMING_E CHOPPER_DEFAULT_24V      // For Extruders (override below)
   //#define CHOPPER_TIMING_E1 CHOPPER_TIMING_E
   //#define CHOPPER_TIMING_E2 CHOPPER_TIMING_E
   //#define CHOPPER_TIMING_E3 CHOPPER_TIMING_E

--- a/config/examples/BIQU/BX/README.md
+++ b/config/examples/BIQU/BX/README.md
@@ -3,3 +3,7 @@
 In `Configuration.h` enable the `MOTHERBOARD BOARD_BTT_SKR_SE_BX_V3` option at the top to specify the BTT SKR SE BX V3.0 motherboard, otherwise the V2.0 board will be applied (slightly farther down).
 
 Enable the `BX_ALL_METAL_HOTEND` option to permit higher printing temperatures for the newer H2 extruder with an all-metal heatbreak.
+
+## Homing with a Probe
+
+This configuration retains the use of homing with a Z limit switch. If you If you want to home with the inductive probe, remove your Z limit switch & bracket and enable (uncomment) `USE_PROBE_FOR_Z_HOMING` and `Z_SAFE_HOMING`.


### PR DESCRIPTION
### Description

- `TOUCH_SCREEN_CALIBRATION` is silently undefined in [`Condtionals_LCD.h`](https://github.com/MarlinFirmware/Marlin/blob/ebea672240ba49067194e9a6959ba2604da2d4c2/Marlin/src/inc/Conditionals_LCD.h#L1859-L1862), so disable the option to prevent confusion.

   _As a test, I disabled the undefines and touch screen calibration / `M995` doesn't work on the BIQU BX screen, which is probably why it was silently undefined in the first place._

- Add a note in the README about homing with a probe for users who are migrating from looxonline's fork and have removed their Z endstop.

- Use `FAN_SOFT_PWM`

-  Extruder has a 1.8° motor, so use `CHOPPER_DEFAULT_24V` for `CHOPPER_TIMING_E` to prevent `CHOPPER_09STEP_24V` from being inherited.


### Benefits

- Clearer config, though the silent undefines would probably be better as a sanity check upstream so it's clear what is & isn't enabled in a config.
- `FAN_SOFT_PWM` commit allows the part cooling fan to work all the way to 1% speed.
- `CHOPPER_TIMING_E` change didn't really affect anything, but it's "more correct".
