### PR TITLE
🐛 Disable Z homing on foamcutters

### DIFF
--- a/config/examples/FoamCutter/generic/Configuration.h
+++ b/config/examples/FoamCutter/generic/Configuration.h
@@ -1803,7 +1803,7 @@
 // :[-1,1]
 #define X_HOME_DIR -1
 #define Y_HOME_DIR -1
-#define Z_HOME_DIR -1
+#define Z_HOME_DIR  0
 #define I_HOME_DIR -1
 #define J_HOME_DIR -1
 //#define K_HOME_DIR -1
@@ -2270,7 +2270,7 @@
 // For DELTA this is the top-center of the Cartesian print volume.
 //#define MANUAL_X_HOME_POS 0
 //#define MANUAL_Y_HOME_POS 0
-//#define MANUAL_Z_HOME_POS 0
+#define MANUAL_Z_HOME_POS 0
 //#define MANUAL_I_HOME_POS 0
 //#define MANUAL_J_HOME_POS 0
 //#define MANUAL_K_HOME_POS 0

--- a/config/examples/FoamCutter/rcKeith/Configuration.h
+++ b/config/examples/FoamCutter/rcKeith/Configuration.h
@@ -1803,7 +1803,7 @@
 // :[-1,1]
 #define X_HOME_DIR -1
 #define Y_HOME_DIR -1
-#define Z_HOME_DIR -1
+#define Z_HOME_DIR  0
 #define I_HOME_DIR -1
 #define J_HOME_DIR -1
 //#define K_HOME_DIR -1
@@ -2270,7 +2270,7 @@
 // For DELTA this is the top-center of the Cartesian print volume.
 //#define MANUAL_X_HOME_POS 0
 //#define MANUAL_Y_HOME_POS 0
-//#define MANUAL_Z_HOME_POS 0
+#define MANUAL_Z_HOME_POS 0
 //#define MANUAL_I_HOME_POS 0
 //#define MANUAL_J_HOME_POS 0
 //#define MANUAL_K_HOME_POS 0


### PR DESCRIPTION
### Description

Don't home dummy Z axis for foamcutters.

### Benefits

fix compilaton with foamcutter configs (bug found by @thisiskeithb )

### Related Issues

- https://github.com/MarlinFirmware/Configurations/pull/1012
- https://github.com/MarlinFirmware/Marlin/pull/24325#discussion_r1469935776