### PR TITLE
✨ Add BIQU BX Z / E1 Motor Swap

### DIFF
--- a/config/examples/BIQU/BX/Configuration.h
+++ b/config/examples/BIQU/BX/Configuration.h
@@ -24,7 +24,8 @@
 #error "Use the 'bugfix...' or 'release...' configurations matching your Marlin version."
 
 //#define MOTHERBOARD BOARD_BTT_SKR_SE_BX_V3 // Uncomment for the V3.0 board, otherwise V2.0 is assumed
-//#define BX_ALL_METAL_HOTEND // Uncomment for newer H2 extruder with all metal heatbreak
+//#define BX_ALL_METAL_HOTEND                // Uncomment for newer H2 extruder with all metal heatbreak
+//#define BX_SWAP_ZM_E1M                     // Uncomment to swap Z and E1 motors
 
 /**
  * Configuration.h

--- a/config/examples/BIQU/BX/README.md
+++ b/config/examples/BIQU/BX/README.md
@@ -4,6 +4,8 @@ In `Configuration.h` enable the `MOTHERBOARD BOARD_BTT_SKR_SE_BX_V3` option at t
 
 Enable the `BX_ALL_METAL_HOTEND` option to permit higher printing temperatures for the newer H2 extruder with an all-metal heatbreak.
 
+Enable the `BX_SWAP_ZM_E1M` option to swap Z and E1 motors if they swapped from the factory. This will fix potential issues with [`G34 - Z Steppers Auto-Alignment`](https://marlinfw.org/docs/gcode/G034-zsaa.html) not working correctly.
+
 ## Homing with a Probe
 
 This configuration retains the use of homing with a Z limit switch. If you If you want to home with the inductive probe, remove your Z limit switch & bracket and enable (uncomment) `USE_PROBE_FOR_Z_HOMING` and `Z_SAFE_HOMING`.


### PR DESCRIPTION
### Description

BiQU BX users can uncomment `#define BX_SWAP_ZM_E1M` instead of opening their printer up & swapping Z & E1 motor cables.

### Benefits

Allows G34 to work correctly on early BX printers since both Z motor wires were installed without a standard procedure in place and wires could be swapped from the factory.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/pull/26871
