### PR TITLE
🔧 Update Ender-5 with SKR Mini E3 V3 TMC slave addresses

### DIFF
--- a/config/examples/Creality/Ender-5/BigTreeTech SKR Mini E3 3.0 with BLTouch/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/BigTreeTech SKR Mini E3 3.0 with BLTouch/Configuration_adv.h
@@ -3260,9 +3260,9 @@
    * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
    * on the same serial port, either here or in your board's pins file.
    */
-  #define  X_SLAVE_ADDRESS 0
-  #define  Y_SLAVE_ADDRESS 2
-  #define  Z_SLAVE_ADDRESS 1
+  //#define  X_SLAVE_ADDRESS 0
+  //#define  Y_SLAVE_ADDRESS 0
+  //#define  Z_SLAVE_ADDRESS 0
   //#define X2_SLAVE_ADDRESS 0
   //#define Y2_SLAVE_ADDRESS 0
   //#define Z2_SLAVE_ADDRESS 0


### PR DESCRIPTION
### Description

There's no need to define TMC slave addresses since they are already [handled correctly in the SKR Mini E3 V3 pins file](https://github.com/MarlinFirmware/Marlin/blob/311bfc99f3f47292f5d4d5e80f29be3de58071a7/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h#L120-L133). They were also not fully defined / missing E0 anyway.

### Benefits

Prevents incorrect TMC slave addresses from being set if this config is recycled into another build with a different motherboard.
