### PR TITLE
🔧 Suppress BIQU Hurakan MicroProbe pull-up warning

### DIFF
--- a/config/examples/BIQU/Hurakan/Configuration.h
+++ b/config/examples/BIQU/Hurakan/Configuration.h
@@ -23,6 +23,8 @@
 #error "Don't build with import-2.1.x configurations!"
 #error "Use the 'bugfix...' or 'release...' configurations matching your Marlin version."
 
+#define NO_MICROPROBE_WARNING // Suppress MicroProbe V2 pull-up warning
+
 /**
  * Configuration.h
  *


### PR DESCRIPTION
### Description

This is a working OEM config and shipped with the MicroProbe connected to the PROBE port.

### Benefits

Prevents confusion since users compiling a stock/OEM Hurakan config do not need to see this warning.
