### PR TITLE
🔧 Update supported Simulator displays

### DIFF
--- a/config/examples/Simulator/Configuration.h
+++ b/config/examples/Simulator/Configuration.h
@@ -46,13 +46,12 @@
 //#define REPRAP_DISCOUNT_SMART_CONTROLLER
 //#define TFT_CLASSIC_UI
 //#define TFT_COLOR_UI
+//#define TFT_LVGL_UI
 
 // Enable parent LCD based on your selection above
-#if ANY(TFT_CLASSIC_UI, TFT_COLOR_UI)
+#if ANY(TFT_CLASSIC_UI, TFT_COLOR_UI, TFT_LVGL_UI)
   #define TFT_GENERIC
   #define TOUCH_SCREEN
-#elif ENABLED(LIGHTWEIGHT_UI)
-  #define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
 #endif
 
 //===========================================================================


### PR DESCRIPTION
### Description

- Since @ellensp & @p3p got `TFT_LVGL_UI` working in the simulator, add it to the list of supported displays.
- As a follow-up to #847, I removed `LIGHTWEIGHT_UI` from the set of conditionals below the supported Simulator display list.
- ~~Fix CI with `BOARD_SIMULATED`~~ Moved to: #1050

### Benefits

More complete list of supported displays in Simulator config.

### Related Issues

- #1050 (required for this PR to pass CI)
- #847
