### PR TITLE
📝 Add Eazao Zero dummy thermistor note

### DIFF
--- a/config/examples/Eazao/Zero/Configuration.h
+++ b/config/examples/Eazao/Zero/Configuration.h
@@ -564,7 +564,7 @@
  *   998 : Dummy Table that ALWAYS reads 25°C or the temperature defined below.
  *   999 : Dummy Table that ALWAYS reads 100°C or the temperature defined below.
  */
-#define TEMP_SENSOR_0 998
+#define TEMP_SENSOR_0 998 // Required for TFT firmware to function properly
 #define TEMP_SENSOR_1 0
 #define TEMP_SENSOR_2 0
 #define TEMP_SENSOR_3 0


### PR DESCRIPTION
### Description

Users will receive a "`Don't use dummy thermistors (998/999) for final build!`" warning during the build, but a dummy thermistor is required for this clay printer to function properly due to TFT firmware limitations.

### Benefits

Document why a dummy thermistor was used.