### PR TITLE
🩹 Fix Formbot T-Rex 3 X2 max position

### DIFF
--- a/config/examples/Formbot/T_Rex_3/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration_adv.h
@@ -824,7 +824,7 @@
   #define X1_MIN_POS X_MIN_POS    // Set to X_MIN_POS
   #define X1_MAX_POS X_BED_SIZE   // A max coordinate so the X1 carriage can't hit the parked X2 carriage
   #define X2_MIN_POS     0        // A min coordinate so the X2 carriage can't hit the parked X1 carriage
-  #define X2_MAX_POS (442-4.0)    // The max position of the X2 carriage, typically also the home position
+  #define X2_MAX_POS   438        // The max position of the X2 carriage, typically also the home position
   #define X2_HOME_POS X2_MAX_POS  // Default X2 home position. Set to X2_MAX_POS.
                                   // NOTE: For Dual X Carriage use M218 T1 Xn to override the X2_HOME_POS.
                                   // This allows recalibration of endstops distance without a rebuild.


### PR DESCRIPTION
### Description

While running the [`build_all_examples`](https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.1.x/buildroot/bin/build_all_examples) script, this config would not build:

```prolog
In file included from Marlin/src/HAL/AVR/../../inc/MarlinConfigPre.h:56:0,
                 from Marlin/src/HAL/AVR/../../inc/MarlinConfig.h:28,
                 from Marlin/src/HAL/AVR/HAL.cpp:24:
Marlin/src/HAL/AVR/../../inc/../../Configuration_adv.h:827:27: error: floating constant in preprocessor expression
   #define X2_MAX_POS (442-4.0)    // The max position of the X2 carriage, typically also the home position
                           ^
```

Removing the extra math & float from `X2_MAX_POS` / setting it to `438` prevents the error and allows the config to build.

### Benefits

Config now builds.

### Related Issues

- #1052
