### PR TITLE
 🔧 Suppress BIQU Hurakan TMC DIAG jumper warning

### DIFF
--- a/config/examples/BIQU/Hurakan/Configuration.h
+++ b/config/examples/BIQU/Hurakan/Configuration.h
@@ -24,6 +24,7 @@
 #error "Use the 'bugfix...' or 'release...' configurations matching your Marlin version."
 
 #define NO_MICROPROBE_WARNING // Suppress MicroProbe V2 pull-up warning
+#define DIAG_JUMPERS_REMOVED  // Suppress TMC DIAG jumper warning
 
 /**
  * Configuration.h


### PR DESCRIPTION
### Description

This is a working OEM config and shipped with TMC DIAG jumpers removed.

### Benefits

Prevents confusion since users compiling a stock/OEM Hurakan config do not need to see this warning.

### Related Issues

- #1045
