### PR TITLE
Update AnyCubic Vyper configuration

### DIFF
--- a/config/examples/AnyCubic/Vyper/Configuration.h
+++ b/config/examples/AnyCubic/Vyper/Configuration.h
@@ -2105,7 +2105,7 @@
    */
   #define ENABLE_LEVELING_FADE_HEIGHT
   #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-    #define DEFAULT_LEVELING_FADE_HEIGHT 10.0 // (mm) Default fade height.
+    #define DEFAULT_LEVELING_FADE_HEIGHT 0.0 // (mm) Default fade height.
   #endif
 
   /**

--- a/config/examples/AnyCubic/Vyper/Configuration.h
+++ b/config/examples/AnyCubic/Vyper/Configuration.h
@@ -1635,12 +1635,12 @@
  * Useful for a strain gauge or piezo sensor that needs to factor out
  * elements such as cables pulling on the carriage.
  */
-//#define PROBE_TARE
+#define PROBE_TARE
 #if ENABLED(PROBE_TARE)
-  #define PROBE_TARE_TIME  200    // (ms) Time to hold tare pin
-  #define PROBE_TARE_DELAY 200    // (ms) Delay after tare before
-  #define PROBE_TARE_STATE HIGH   // State to write pin for tare
-  //#define PROBE_TARE_PIN PA5    // Override default pin
+  #define PROBE_TARE_TIME  300    // (ms) Time to hold tare pin
+  #define PROBE_TARE_DELAY 100    // (ms) Delay after tare before
+  #define PROBE_TARE_STATE LOW   // State to write pin for tare
+  #define PROBE_TARE_PIN AUTO_LEVEL_TX_PIN // Override default pin
   #if ENABLED(PROBE_ACTIVATION_SWITCH)
     //#define PROBE_TARE_ONLY_WHILE_INACTIVE  // Fail to tare/probe if PROBE_ACTIVATION_SWITCH is active
   #endif

--- a/config/examples/AnyCubic/Vyper/Configuration_adv.h
+++ b/config/examples/AnyCubic/Vyper/Configuration_adv.h
@@ -681,7 +681,7 @@
  * Multiple extruders can be assigned to the same pin in which case
  * the fan will turn on when any selected extruder is above the threshold.
  */
-//#define E0_AUTO_FAN_PIN PB1
+#define E0_AUTO_FAN_PIN PB1
 #define E1_AUTO_FAN_PIN -1
 #define E2_AUTO_FAN_PIN -1
 #define E3_AUTO_FAN_PIN -1


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

Configuration update for AnyCubic Vyper

### Benefits

<!-- What does this fix or improve? -->
 - Activate cooling fan for extruder 0, with actual config the fan never start (I don't understand why this is commented)
 - Activate tare with value from OEM firmware, it is needed for the probing to complete. If not set the filament pull on the head and the probe fail when the head is in the middle.
 - Disable leveling fade by default (like OEM firmware), because the the probed position is more than 2 mm bellow the zero point and using the printer just after G29 cause massive z error with actual value of 10

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
None
