### PR TITLE
🎨 Use standard STRING_CONFIG_H_AUTHOR format

### DIFF
--- a/config/default/Configuration.h
+++ b/config/default/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(MarlinFirmware)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/3DFabXYZ/Migbot/Configuration.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "AJMartel"  // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(AJMartel)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 #define WEBSITE_URL "http://3DFabXYZ.com"
 

--- a/config/examples/3DMatik/XL/Configuration.h
+++ b/config/examples/3DMatik/XL/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Fernando Bergami)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Alfawise/U20-bltouch/Configuration.h
+++ b/config/examples/Alfawise/U20-bltouch/Configuration.h
@@ -101,7 +101,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "Hobi, tpruvot"  // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Hobi, tpruvot)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Alfawise/U20/Configuration.h
+++ b/config/examples/Alfawise/U20/Configuration.h
@@ -101,7 +101,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "Hobi, tpruvot"  // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Hobi, tpruvot)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/AliExpress/UM2pExt/Configuration.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Vasily Evseenko)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Anet/E10/Configuration.h
+++ b/config/examples/Anet/E10/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "default" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Anet/E10/Configuration.h
+++ b/config/examples/Anet/E10/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Boris Sedov)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Anet/E16/Stock/Configuration.h
+++ b/config/examples/Anet/E16/Stock/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "InsanityAutomation" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(InsanityAutomation)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Anet/ET4+/Configuration.h
+++ b/config/examples/Anet/ET4+/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Scott Lahteine)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Anet/ET4/Configuration.h
+++ b/config/examples/Anet/ET4/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Scott Lahteine)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/AnyCubic/Vyper/Configuration.h
+++ b/config/examples/AnyCubic/Vyper/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Bob Kuhn)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/AnyCubic/i3 Mega/Trigorilla AVR/Configuration.h
+++ b/config/examples/AnyCubic/i3 Mega/Trigorilla AVR/Configuration.h
@@ -67,7 +67,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Jonathan Amsterdam)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/AnyCubic/i3/Configuration.h
+++ b/config/examples/AnyCubic/i3/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Bo Herrmannsen)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/ArmEd/Configuration.h
+++ b/config/examples/ArmEd/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Karl Andersson)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Artillery/Genius Pro/Configuration.h
+++ b/config/examples/Artillery/Genius Pro/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "thisiskeithb, Genius Pro" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(thisiskeithb, Genius Pro)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Artillery/Hornet/Configuration.h
+++ b/config/examples/Artillery/Hornet/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "thisiskeithb, Artillery 3D" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(thisiskeithb, Artillery 3D)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Artillery/Sidewinder X1/0.9 BMG - E3D V6/Configuration.h
+++ b/config/examples/Artillery/Sidewinder X1/0.9 BMG - E3D V6/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "Robert Vandervoort" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Robert Vandervoort)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Artillery/Sidewinder X2/Configuration.h
+++ b/config/examples/Artillery/Sidewinder X2/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "thisiskeithb, Artillery 3D" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(thisiskeithb, Artillery 3D)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Azteeg/X5GT/Configuration.h
+++ b/config/examples/Azteeg/X5GT/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Alexey Shvetsov)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/BIBO/TouchX/cyclops/Configuration.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Rajesh Vaidheeswarran)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/BIBO/TouchX/default - BLTouch/Configuration.h
+++ b/config/examples/BIBO/TouchX/default - BLTouch/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Rajesh Vaidheeswarran, Walt Sorensen)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/config/examples/BIBO/TouchX/default/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Rajesh Vaidheeswarran)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/BQ/Hephestos/Configuration.h
+++ b/config/examples/BQ/Hephestos/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Scott Lahteine)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/config/examples/BQ/Hephestos_2/Configuration.h
@@ -71,7 +71,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "@jbrazio" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@jbrazio)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/CTC/Bizer/Configuration.h
+++ b/config/examples/CTC/Bizer/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "Simon Pilepich" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Simon Pilepich)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/CR-10 Max/Configuration.h
+++ b/config/examples/Creality/CR-10 Max/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(anonymous)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/CR-10 Max/Configuration.h
+++ b/config/examples/Creality/CR-10 Max/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(Peter Ellens)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/CR-10 Max/Configuration.h
+++ b/config/examples/Creality/CR-10 Max/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Peter Ellens)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/CR-10 Mini/CrealityV1/Configuration.h
+++ b/config/examples/Creality/CR-10 Mini/CrealityV1/Configuration.h
@@ -72,7 +72,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Larry Kraemer)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/CR-10 S5/CrealityV427 - BLTouch/Configuration.h
+++ b/config/examples/Creality/CR-10 S5/CrealityV427 - BLTouch/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "JPT" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(JPT)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/CR-10 V2/Configuration.h
+++ b/config/examples/Creality/CR-10 V2/Configuration.h
@@ -70,7 +70,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "fran6p, CR-10 V2)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(fran6p, CR-10 V2)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/CR-10 V3/Configuration.h
+++ b/config/examples/Creality/CR-10 V3/Configuration.h
@@ -70,7 +70,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "Aaron Just, CR-10 V3)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Aaron Just, CR-10 V3)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/CR-10S Pro/Configuration.h
+++ b/config/examples/Creality/CR-10S Pro/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@JoeEn)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/CR-10S/CrealityV1 - BLTouch/Configuration.h
+++ b/config/examples/Creality/CR-10S/CrealityV1 - BLTouch/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Anes Belfodil)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/CR-20/RepRapWorld Minitronics20/Configuration.h
+++ b/config/examples/Creality/CR-20/RepRapWorld Minitronics20/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Bart Meijer)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/CR-30 PrintMill/Configuration.h
+++ b/config/examples/Creality/CR-30 PrintMill/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "3DPrintMill" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(3DPrintMill)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/CR-6 SE/Configuration.h
+++ b/config/examples/Creality/CR-6 SE/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "CR-6 SE" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(CR-6 SE)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-2 Pro/CrealityV24S4/Configuration.h
+++ b/config/examples/Creality/Ender-2 Pro/CrealityV24S4/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Cesar Guillermo Montiel)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 Max Neo/Configuration.h
+++ b/config/examples/Creality/Ender-3 Max Neo/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(anonymous)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 Max Neo/Configuration.h
+++ b/config/examples/Creality/Ender-3 Max Neo/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(Peter Ellens)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 Max Neo/Configuration.h
+++ b/config/examples/Creality/Ender-3 Max Neo/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Peter Ellens)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 Max/Configuration.h
+++ b/config/examples/Creality/Ender-3 Max/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Chad Schwieterman)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 Pro/CrealityV427 - BLTouch/Configuration.h
+++ b/config/examples/Creality/Ender-3 Pro/CrealityV427 - BLTouch/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "JPT" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(JPT)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 S1/STM32F1/Configuration.h
+++ b/config/examples/Creality/Ender-3 S1/STM32F1/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Sebastiaan Dammann)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 V2 Neo/BigTreeTech SKR Mini E3 3.0/Configuration.h
+++ b/config/examples/Creality/Ender-3 V2 Neo/BigTreeTech SKR Mini E3 3.0/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(anonymous)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 V2 Neo/BigTreeTech SKR Mini E3 3.0/Configuration.h
+++ b/config/examples/Creality/Ender-3 V2 Neo/BigTreeTech SKR Mini E3 3.0/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(Peter Ellens)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 V2 Neo/BigTreeTech SKR Mini E3 3.0/Configuration.h
+++ b/config/examples/Creality/Ender-3 V2 Neo/BigTreeTech SKR Mini E3 3.0/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Peter Ellens)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 V2 Neo/CrealityV422/Configuration.h
+++ b/config/examples/Creality/Ender-3 V2 Neo/CrealityV422/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(anonymous)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 V2 Neo/CrealityV422/Configuration.h
+++ b/config/examples/Creality/Ender-3 V2 Neo/CrealityV422/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(Peter Ellens)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 V2 Neo/CrealityV422/Configuration.h
+++ b/config/examples/Creality/Ender-3 V2 Neo/CrealityV422/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Peter Ellens)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR E3 Turbo/CrealityUI/Configuration.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR E3 Turbo/CrealityUI/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Scott Lahteine)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR E3 Turbo/MarlinUI/Configuration.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR E3 Turbo/MarlinUI/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Scott Lahteine)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 2.0/CrealityUI/Configuration.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 2.0/CrealityUI/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Scott Lahteine)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 2.0/MarlinUI/Configuration.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 2.0/MarlinUI/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Scott Lahteine)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 3.0/CrealityUI/Configuration.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 3.0/CrealityUI/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Scott Lahteine)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 3.0/MarlinUI/Configuration.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 3.0/MarlinUI/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Scott Lahteine)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 V2/CrealityV422/CrealityUI/Configuration.h
+++ b/config/examples/Creality/Ender-3 V2/CrealityV422/CrealityUI/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Scott Lahteine)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 V2/CrealityV422/MarlinUI/Configuration.h
+++ b/config/examples/Creality/Ender-3 V2/CrealityV422/MarlinUI/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Scott Lahteine)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 V2/CrealityV427/CrealityUI/Configuration.h
+++ b/config/examples/Creality/Ender-3 V2/CrealityV427/CrealityUI/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Scott Lahteine)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3 V2/CrealityV427/MarlinUI/Configuration.h
+++ b/config/examples/Creality/Ender-3 V2/CrealityV427/MarlinUI/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Scott Lahteine)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3/FYSETC Cheetah 1.2/BLTouch/Configuration.h
+++ b/config/examples/Creality/Ender-3/FYSETC Cheetah 1.2/BLTouch/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Eric Ptak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3/FYSETC Cheetah 1.2/base/Configuration.h
+++ b/config/examples/Creality/Ender-3/FYSETC Cheetah 1.2/base/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Eric Ptak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3/FYSETC Cheetah 2.0/Configuration.h
+++ b/config/examples/Creality/Ender-3/FYSETC Cheetah 2.0/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(George Fu)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3/FYSETC Cheetah/BLTouch/Configuration.h
+++ b/config/examples/Creality/Ender-3/FYSETC Cheetah/BLTouch/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Eric Ptak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-3/FYSETC Cheetah/base/Configuration.h
+++ b/config/examples/Creality/Ender-3/FYSETC Cheetah/base/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Eric Ptak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Creality/Ender-5 S1/Configuration.h
+++ b/config/examples/Creality/Ender-5 S1/Configuration.h
@@ -66,7 +66,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "Creality" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Creality)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 #define MACHINE_NAME      "Ender-5 S1"

--- a/config/examples/Dagoma/Disco Ultimate/Configuration.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "Dagoma" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Dagoma)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Daycom/3DP-100/Configuration.h
+++ b/config/examples/Daycom/3DP-100/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Thomas Hollstegge)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/EXP3D/Imprimante multifonction/Configuration.h
+++ b/config/examples/EXP3D/Imprimante multifonction/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(Vertabreaker)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Vertabreak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/EasyThreeD/ET4000PLUS/Configuration.h
+++ b/config/examples/EasyThreeD/ET4000PLUS/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@schmttc)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Einstart-S/Configuration.h
+++ b/config/examples/Einstart-S/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "elsie tech corp" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(elsie tech corp)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/FYSETC/AIO_II/Configuration.h
+++ b/config/examples/FYSETC/AIO_II/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Eric Ptak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/FYSETC/F6_13/Configuration.h
+++ b/config/examples/FYSETC/F6_13/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Eric Ptak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/FYSETC/S6/Configuration.h
+++ b/config/examples/FYSETC/S6/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(George Fu)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/FlashForge/Creator 2X/Configuration.h
+++ b/config/examples/FlashForge/Creator 2X/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "MakerHouse" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(MakerHouse)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/FlashForge/CreatorPro/Configuration.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "M. Baker, Queen Vinyl Da.i'gyu-Kazotetsu" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(M. Baker, Queen Vinyl Da.i'gyu-Kazotetsu)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/FlyingBear/P902/Configuration.h
+++ b/config/examples/FlyingBear/P902/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "Doc" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Doc)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/FlyingBear/P905H/Configuration.h
+++ b/config/examples/FlyingBear/P905H/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "Rumato Estorsky" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Rumato Estorsky)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/FoamCutter/generic/Configuration.h
+++ b/config/examples/FoamCutter/generic/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@DerAndere)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/FoamCutter/rcKeith/Configuration.h
+++ b/config/examples/FoamCutter/rcKeith/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "rcKeith, HotWire CNC" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(rcKeith, HotWire CNC)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/FolgerTech/FT-5 R2/Configuration.h
+++ b/config/examples/FolgerTech/FT-5 R2/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(MasterofNull)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Roxy-3D)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Formbot/Raptor/Configuration.h
+++ b/config/examples/Formbot/Raptor/Configuration.h
@@ -106,7 +106,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "Tinymachines3D" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Tinymachines3D)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Formbot/T_Rex_2+/Configuration.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "Formbot-3D" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Formbot-3D)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Formbot/T_Rex_3/Configuration.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration.h
@@ -66,7 +66,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "Formbot-3D" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Formbot-3D)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/A10/Configuration.h
+++ b/config/examples/Geeetech/A10/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(Phr3d13, Geeetech A10 default)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Phr3d13, Geeetech)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/A10D/Configuration.h
+++ b/config/examples/Geeetech/A10D/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(default)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Geeetech)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/A10M/Stock LCD/Configuration.h
+++ b/config/examples/Geeetech/A10M/Stock LCD/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Phr3d13, Geeetech)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/A10M/YHCB2004_V4.1/Configuration.h
+++ b/config/examples/Geeetech/A10M/YHCB2004_V4.1/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Geeetech)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/A10PRO/Configuration.h
+++ b/config/examples/Geeetech/A10PRO/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(Phr3d13, Geeetech A10 default)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Phr3d13, Geeetech)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/A10T/Stock LCD/Configuration.h
+++ b/config/examples/Geeetech/A10T/Stock LCD/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Geeetech)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/A10T/YHCB2004_V4.1/Configuration.h
+++ b/config/examples/Geeetech/A10T/YHCB2004_V4.1/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Geeetech)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/A20/Configuration.h
+++ b/config/examples/Geeetech/A20/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Geeetech)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/A20M/Configuration.h
+++ b/config/examples/Geeetech/A20M/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@thinkyhead)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/A20T/Configuration.h
+++ b/config/examples/Geeetech/A20T/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Geeetech)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/A30/Configuration.h
+++ b/config/examples/Geeetech/A30/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Geeetech)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/A30M/Configuration.h
+++ b/config/examples/Geeetech/A30M/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Geeetech)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/A30T/Configuration.h
+++ b/config/examples/Geeetech/A30T/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Geeetech)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/D200/Configuration.h
+++ b/config/examples/Geeetech/D200/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Vertabreak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/Duplicator5/Configuration.h
+++ b/config/examples/Geeetech/Duplicator5/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Vertabreak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/E180/Configuration.h
+++ b/config/examples/Geeetech/E180/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Vertabreak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/GT2560/Configuration.h
+++ b/config/examples/Geeetech/GT2560/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Jozsef Kiraly)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/M201/Configuration.h
+++ b/config/examples/Geeetech/M201/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Vertabreak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/Me_creator/Configuration.h
+++ b/config/examples/Geeetech/Me_creator/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Phr3d13)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Geeetech/Me_ducer/Configuration.h
+++ b/config/examples/Geeetech/Me_ducer/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Vertabreak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Intamsys/FunmatHT 4988/Configuration.h
+++ b/config/examples/Intamsys/FunmatHT 4988/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "3DXtech / Insanity Automation" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(3DXtech / Insanity Automation)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/JGAurora/A3/Configuration.h
+++ b/config/examples/JGAurora/A3/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Dingo420)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/JGAurora/Magic/Configuration.h
+++ b/config/examples/JGAurora/Magic/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Vertabreak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Kingroon/KP3S_Pro/Configuration.h
+++ b/config/examples/Kingroon/KP3S_Pro/Configuration.h
@@ -84,7 +84,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "ack ack" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(ack ack)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Kingroon/KP5L-DIY/Configuration.h
+++ b/config/examples/Kingroon/KP5L-DIY/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(anonymous)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Kingroon/KP5L-DIY/Configuration.h
+++ b/config/examples/Kingroon/KP5L-DIY/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(Peter Ellens)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Kingroon/KP5L-DIY/Configuration.h
+++ b/config/examples/Kingroon/KP5L-DIY/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Peter Ellens)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Labists/ET4/Configuration.h
+++ b/config/examples/Labists/ET4/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Keith Bennett)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Longer/LK5/Configuration.h
+++ b/config/examples/Longer/LK5/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "Longer3D, Hobi, tpruvot, Dust"  // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Longer3D, Hobi, tpruvot, Dust)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/MBot/Cube/Configuration.h
+++ b/config/examples/MBot/Cube/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "M. Baker" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(M. Baker)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/MakerFarm/Pegasus 12/Configuration.h
+++ b/config/examples/MakerFarm/Pegasus 12/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Vertabreak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/MakerParts/Configuration.h
+++ b/config/examples/MakerParts/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "ejtagle" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(ejtagle)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/MakerTech3D/Proforge2sDual/Configuration.h
+++ b/config/examples/MakerTech3D/Proforge2sDual/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "FM for the Makertech 3D Profoge 2s Dual"      // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(FM for the Makertech 3D Profoge 2s Dual)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Malyan/M180/Configuration.h
+++ b/config/examples/Malyan/M180/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Timo Birnschein, Microforge)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Mks/Robin/Configuration.h
+++ b/config/examples/Mks/Robin/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Alexander Gavrilenko)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Mks/Robin_Lite3/Configuration.h
+++ b/config/examples/Mks/Robin_Lite3/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@MS1987)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Mks/Robin_Pro/Configuration.h
+++ b/config/examples/Mks/Robin_Pro/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@MS1987)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Mks/Sbase/Configuration.h
+++ b/config/examples/Mks/Sbase/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Spawn32)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Modix/Big60/Configuration.h
+++ b/config/examples/Modix/Big60/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "3DXtech" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(3DXtech)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Nextion/Configuration.h
+++ b/config/examples/Nextion/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Scott Lahteine)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Opulo/Lumen_REV3/Configuration.h
+++ b/config/examples/Opulo/Lumen_REV3/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Stephen Hawes)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Opulo/Lumen_REV4/Configuration.h
+++ b/config/examples/Opulo/Lumen_REV4/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Stephen Hawes)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Printrbot/PrintrboardG2/Configuration.h
+++ b/config/examples/Printrbot/PrintrboardG2/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Bob Kuhn)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Printrbot/Simple Metal RevD/Configuration.h
+++ b/config/examples/Printrbot/Simple Metal RevD/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Charles Pirnat)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Qidi/Qidi 1/Configuration.h
+++ b/config/examples/Qidi/Qidi 1/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "Axel S." // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Axel S.)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Renkforce/RF100/Configuration.h
+++ b/config/examples/Renkforce/RF100/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Dirk O. Kaar)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Renkforce/RF100XL/Configuration.h
+++ b/config/examples/Renkforce/RF100XL/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Dirk O. Kaar)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Renkforce/RF100v2/Configuration.h
+++ b/config/examples/Renkforce/RF100v2/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Dirk O. Kaar)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "RepRapWorld.com" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(RepRapWorld.com)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/RepRapWorld/Minitronics20/CNC/Configuration.h
+++ b/config/examples/RepRapWorld/Minitronics20/CNC/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Bart Meijer)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/SCARA/MP_SCARA/Configuration.h
+++ b/config/examples/SCARA/MP_SCARA/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@cocktailyogi)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/SCARA/Morgan/Configuration.h
+++ b/config/examples/SCARA/Morgan/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@cocktailyogi)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Karl Andersson)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/STM32/STM32F103RE/Configuration.h
+++ b/config/examples/STM32/STM32F103RE/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "Victor Perez" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Victor Perez)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Simax/Mi-M200/Configuration.h
+++ b/config/examples/Simax/Mi-M200/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@kukumagi)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Simulator/Configuration.h
+++ b/config/examples/Simulator/Configuration.h
@@ -78,7 +78,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Chris Pepper)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Sovol/SV-01/BigTreeTech SKR E3 Turbo/Configuration.h
+++ b/config/examples/Sovol/SV-01/BigTreeTech SKR E3 Turbo/Configuration.h
@@ -67,7 +67,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "FOG_Yamato, SV-01" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(FOG_Yamato, SV-01)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Sovol/SV-01/BigTreeTech SKR Mini E3 2.0/Configuration.h
+++ b/config/examples/Sovol/SV-01/BigTreeTech SKR Mini E3 2.0/Configuration.h
@@ -66,7 +66,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "FOG_Yamato, SV-01" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(FOG_Yamato, SV-01)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Sovol/SV-01/BigTreeTech SKR Mini E3 3.0/Configuration.h
+++ b/config/examples/Sovol/SV-01/BigTreeTech SKR Mini E3 3.0/Configuration.h
@@ -67,7 +67,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "0Hertz, SV-01" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(0Hertz, SV-01)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Sovol/SV-01/CrealityV22/Configuration.h
+++ b/config/examples/Sovol/SV-01/CrealityV22/Configuration.h
@@ -66,7 +66,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "ils15" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(ils15)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Sovol/SV-01/CrealityV221/Configuration.h
+++ b/config/examples/Sovol/SV-01/CrealityV221/Configuration.h
@@ -66,7 +66,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "ils15" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(ils15)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Sovol/SV-02/Configuration.h
+++ b/config/examples/Sovol/SV-02/Configuration.h
@@ -66,7 +66,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "ils15" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(ils15)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Sunlu/S8/Configuration.h
+++ b/config/examples/Sunlu/S8/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "InsanityAutomation" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(InsanityAutomation)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/TPARA/AXEL_TPARA/Configuration.h
+++ b/config/examples/TPARA/AXEL_TPARA/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Axel Sepúlveda)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Tronxy/D01/CXY-v6-191017 board/Configuration.h
+++ b/config/examples/Tronxy/D01/CXY-v6-191017 board/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Alex Z)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Tronxy/D01/CXY-v6-191017 board/Configuration.h
+++ b/config/examples/Tronxy/D01/CXY-v6-191017 board/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "username" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Tronxy/X5S/Configuration.h
+++ b/config/examples/Tronxy/X5S/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Scott Lahteine)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Tronxy/X5SA-2E/Configuration.h
+++ b/config/examples/Tronxy/X5SA-2E/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@VTXtruder)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Tronxy/X5SA/Configuration.h
+++ b/config/examples/Tronxy/X5SA/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Victor Oliveira)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Two Trees/SP-5_V3/Configuration.h
+++ b/config/examples/Two Trees/SP-5_V3/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(anonymous)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Two Trees/SP-5_V3/Configuration.h
+++ b/config/examples/Two Trees/SP-5_V3/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(Peter Ellens)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Two Trees/SP-5_V3/Configuration.h
+++ b/config/examples/Two Trees/SP-5_V3/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Peter Ellens)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/UltiMachine/Archim1/Configuration.h
+++ b/config/examples/UltiMachine/Archim1/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Allted)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/config/examples/UltiMachine/Archim2/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@victorpv)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Ultimaker/Ultimaker 2/Configuration.h
+++ b/config/examples/Ultimaker/Ultimaker 2/Configuration.h
@@ -65,7 +65,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Alex von Gluck IV)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Ultimaker/Ultimaker Original (1.5.7)/Configuration.h
+++ b/config/examples/Ultimaker/Ultimaker Original (1.5.7)/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(MrAlvin)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/VORONDesign/Configuration.h
+++ b/config/examples/VORONDesign/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Ludy)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Wanhao/Duplicator 4S/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 4S/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "MakerHouse" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(MakerHouse)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(Rob Mendon, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Rob Mendon)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Wanhao/Duplicator i3 Plus/Configuration.h
+++ b/config/examples/Wanhao/Duplicator i3 Plus/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Ryan Finnie)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Weedo/Tina2/V2/Configuration.h
+++ b/config/examples/Weedo/Tina2/V2/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "atsju" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(atsju)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Weedo/Tina2/V3/Configuration.h
+++ b/config/examples/Weedo/Tina2/V3/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "atsju" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(atsju)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/delta/Anycubic/Kossel Linear Plus/Configuration.h
+++ b/config/examples/delta/Anycubic/Kossel Linear Plus/Configuration.h
@@ -78,7 +78,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "@brandstaetter, @grbd" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@brandstaetter, @grbd)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -78,7 +78,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "@brandstaetter, @grbd" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@brandstaetter, @grbd)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/delta/Geeetech/G2/Configuration.h
+++ b/config/examples/delta/Geeetech/G2/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Vertabreak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/delta/Geeetech/G2Pro/Configuration.h
+++ b/config/examples/delta/Geeetech/G2Pro/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Vertabreak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/delta/Geeetech/G2S/Configuration.h
+++ b/config/examples/delta/Geeetech/G2S/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Vertabreak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/delta/Geeetech/G2SPro/Configuration.h
+++ b/config/examples/delta/Geeetech/G2SPro/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Vertabreak)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -68,7 +68,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Scott Lahteine)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/delta/MKS/SBASE/Configuration.h
+++ b/config/examples/delta/MKS/SBASE/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(David Bates)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/delta/generic/Configuration.h
+++ b/config/examples/delta/generic/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Jim Morris)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/delta/kossel_mini/Configuration.h
+++ b/config/examples/delta/kossel_mini/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Jim Morris)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/delta/kossel_pro/Configuration.h
+++ b/config/examples/delta/kossel_pro/Configuration.h
@@ -67,7 +67,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Richard Wackerbarth)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@Roxy-3D)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/linear_axes/Octopus 8 LINEAR_AXES/Configuration.h
+++ b/config/examples/linear_axes/Octopus 8 LINEAR_AXES/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(anonymous)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/linear_axes/Octopus 8 LINEAR_AXES/Configuration.h
+++ b/config/examples/linear_axes/Octopus 8 LINEAR_AXES/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(Peter Ellens)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/linear_axes/Octopus 8 LINEAR_AXES/Configuration.h
+++ b/config/examples/linear_axes/Octopus 8 LINEAR_AXES/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Peter Ellens)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/linear_axes/RAMPS 5 LINEAR_AXES/Configuration.h
+++ b/config/examples/linear_axes/RAMPS 5 LINEAR_AXES/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(anonymous)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/linear_axes/RAMPS 5 LINEAR_AXES/Configuration.h
+++ b/config/examples/linear_axes/RAMPS 5 LINEAR_AXES/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(Peter Ellens)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/linear_axes/RAMPS 5 LINEAR_AXES/Configuration.h
+++ b/config/examples/linear_axes/RAMPS 5 LINEAR_AXES/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Peter Ellens)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/makibox/Configuration.h
+++ b/config/examples/makibox/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Cameron Lai)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/tvrrug/Round2/Configuration.h
+++ b/config/examples/tvrrug/Round2/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(none, default config)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(Bo Herrmannsen)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine


### PR DESCRIPTION
### Description

Wrap `STRING_CONFIG_H_AUTHOR` string in parenthesis per default & most configs.

### Benefits

Configs will match the standard `STRING_CONFIG_H_AUTHOR` format.

> [!NOTE]  
> Several configs will not build & will cause CI to fail, but they are a known issue. See https://github.com/MarlinFirmware/Configurations/issues/1068 for more details.
