### PR TITLE
🔧 Define Malyan M300 E0_AUTO_FAN_PIN directly (again)

### DIFF
--- a/config/examples/delta/Malyan M300/Configuration_adv.h
+++ b/config/examples/delta/Malyan M300/Configuration_adv.h
@@ -681,7 +681,7 @@
  * Multiple extruders can be assigned to the same pin in which case
  * the fan will turn on when any selected extruder is above the threshold.
  */
-//#define E0_AUTO_FAN_PIN -1  // Provided by the pins file
+#define E0_AUTO_FAN_PIN PA8
 #define E1_AUTO_FAN_PIN -1
 #define E2_AUTO_FAN_PIN -1
 #define E3_AUTO_FAN_PIN -1


### PR DESCRIPTION
### Description

I had defined the `E0_AUTO_FAN_PIN` directly for this config in #1074 to get https://github.com/MarlinFirmware/Marlin/pull/27214 passing CI tests, but the "for now… " commit (92ce6f46f) that was added before #1074 was merged left the config in an unsafe state. 

The M300 pins file [defines an `AUTO_FAN_PIN`](https://github.com/MarlinFirmware/Marlin/blob/9240ec89d034632443d02baaeb140acc3134c67f/Marlin/src/pins/stm32f0/pins_MALYAN_M300.h#L93) which does nothing. Without an `E0_AUTO_FAN_PIN` defined, the hotend cooling fan does not turn on.

Since https://github.com/MarlinFirmware/Marlin/pull/27214 is a work in progress / in the "After 2.1.3" milestone, it leaves this config in an unsafe state and will be broken for `2.1.3`.

I can submit another PR that will use the "standard" method of commenting out `E0_AUTO_FAN_PIN` as intended by the last comment in #1074 if/when https://github.com/MarlinFirmware/Marlin/pull/27214 is ever merged.

### Benefits

Malyan M300 config will work / be safe again.

### Related Issues

- #1074
- https://github.com/MarlinFirmware/Marlin/pull/27214

