### PR TITLE
✨ Add Simulator "secret" TCP port

### DIFF
--- a/config/examples/Simulator/Configuration.h
+++ b/config/examples/Simulator/Configuration.h
@@ -118,7 +118,7 @@
  * Currently Ethernet (-2) is only supported on Teensy 4.1 boards.
  * :[-2, -1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-//#define SERIAL_PORT_2 -1
+//#define SERIAL_PORT_2 3     // Raw TCP connection on localhost:8099
 //#define BAUDRATE_2 250000   // :[2400, 9600, 19200, 38400, 57600, 115200, 250000, 500000, 1000000] Enable to override BAUDRATE
 
 /**


### PR DESCRIPTION
### Description

Add the Simulator's "secret" TCP port. Tested with `telnet localhost 8099` on macOS:

<img width="424" alt="image" src="https://github.com/MarlinFirmware/Configurations/assets/13375512/d2e49fd6-a9fa-4de9-b665-fdbf6cc61d32">

---

If you prefer a GUI like PuTTY, create a new connection with the following details:

- Set **Host Name** to `localhost`
- Set **Port** to `8099`
- Set **Connection type** to `Other: Raw`:

<img src="https://github.com/MarlinFirmware/Configurations/assets/13375512/d5e6c758-46fd-440e-a4e2-320218687a11" width="50%">

Then navigate to the **Terminal** Category and ensure the `Implicit CR in every LF` box is checked:

<img src="https://github.com/MarlinFirmware/Configurations/assets/13375512/be08b1df-31e7-4d03-bb3c-16a62630e027" width="50%">

 H/t to @p3p for the information! 

### Benefits

You can now send/receive serial commands to the Simulator externally.