### PR TITLE
Sovol SV06 fix probe X offset

### DIFF
--- a/config/examples/Sovol/SV-06/Configuration.h
+++ b/config/examples/Sovol/SV-06/Configuration.h
@@ -1606,7 +1606,7 @@
  *     |    [-]    |
  *     O-- FRONT --+
  */
-#define NOZZLE_TO_PROBE_OFFSET { 28, -20, 0 }
+#define NOZZLE_TO_PROBE_OFFSET { 27, -20, 0 }
 
 // Enable and set to use a specific tool for probing. Disable to allow any tool.
 #define PROBING_TOOL 0


### PR DESCRIPTION
### Requirements

<!--
* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.
-->

### Description

This is bottom view of Sovol SV06 toolhead CAD:
![image](https://github.com/user-attachments/assets/c2c75867-5c67-49ac-b80c-d33a2d252742)

The CAD indicates the probe X offset is +27mm.

This PR fixes probe X offset from +28mm to +27mm.

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
