### PR TITLE
Fix Z_CLEARANCE_FOR_HOMING for FLSUN Delta printer

### DIFF
--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
@@ -1822,7 +1822,7 @@
  */
 //#define Z_IDLE_HEIGHT Z_HOME_POS
 
-#define Z_CLEARANCE_FOR_HOMING   15   // (mm) Minimal Z height before homing (G28) for Z clearance above the bed, clamps, ...
+#define Z_CLEARANCE_FOR_HOMING   0   // (mm) Minimal Z height before homing (G28) for Z clearance above the bed, clamps, ...
                                       // You'll need this much clearance above Z_MAX_POS to avoid grinding.
 
 //#define Z_AFTER_HOMING         10   // (mm) Height to move to after homing (if Z was homed)


### PR DESCRIPTION
### Description

This config had

```
#define Z_HOME_DIR 1
#define HOME_Z_FIRST
#define Z_CLEARANCE_FOR_HOMING 15
```

Theoretically this combo cannot work. Homing will
1. home Z to max
2.  Raise Z for Z_CLEARANCE_FOR_HOMING (15mm)

Maybe I oversaw some special homing logic for DELTA printers that prevent the crash into Z max during homing. Or users of this printer always used G28 R0 instead of G28 as a workaround? Or this printer can move past the Zmax limit switch?


### Benefits

prevent a crash into Z max during G28


### Related Issues

[#27370](https://github.com/MarlinFirmware/Marlin/pull/27370)