### PR TITLE
fix Z_CLEARANCE_FOR_HOMING

### DIFF
--- a/config/examples/CNC/miniRambo/Configuration.h
+++ b/config/examples/CNC/miniRambo/Configuration.h
@@ -1810,7 +1810,7 @@
  */
 //#define Z_IDLE_HEIGHT Z_HOME_POS
 
-#define Z_CLEARANCE_FOR_HOMING  0   // (mm) Minimal Z height before homing (G28) for Z clearance above the bed, clamps, ...
+#define Z_CLEARANCE_FOR_HOMING  0     // (mm) Minimal Z height before homing (G28) for Z clearance above the bed, clamps, ...
                                       // You'll need this much clearance above Z_MAX_POS to avoid grinding.
 
 //#define Z_AFTER_HOMING         10   // (mm) Height to move to after homing (if Z was homed)

--- a/config/examples/CNC/miniRambo/Configuration.h
+++ b/config/examples/CNC/miniRambo/Configuration.h
@@ -1810,7 +1810,7 @@
  */
 //#define Z_IDLE_HEIGHT Z_HOME_POS
 
-//#define Z_CLEARANCE_FOR_HOMING  4   // (mm) Minimal Z height before homing (G28) for Z clearance above the bed, clamps, ...
+#define Z_CLEARANCE_FOR_HOMING  0   // (mm) Minimal Z height before homing (G28) for Z clearance above the bed, clamps, ...
                                       // You'll need this much clearance above Z_MAX_POS to avoid grinding.
 
 //#define Z_AFTER_HOMING         10   // (mm) Height to move to after homing (if Z was homed)


### PR DESCRIPTION
### Description

The CNC/miniRambo  config had

```
#define Z_HOME_DIR 1
#define HOME_Z_FIRST
//#define Z_CLEARANCE_FOR_HOMING 4
#define Z_CLEARANCE_BETWEEN_PROBES  5
```

Theoretically this combo cannot work. Homing would
1. home Z to max
2.  Raise Z for Z_CLEARANCE_FOR_HOMING (using fall back Z_CLEARANCE_BETWEEN_PROBES)

Maybe users of this machine always used G28 R0 instead of G28 as a workaround? Or this machine can move past the Zmax limit switch?

I now added
```
#define Z_CLEARANCE_FOR_HOMING 0
```

### Benefits

prevent a crash into Z max during G28


### Related Issues

[#27370](https://github.com/MarlinFirmware/Marlin/pull/27370)
