### PR TITLE
🔧 English as default on Ender-5 S1

### DIFF
--- a/config/examples/Creality/Ender-5 S1/Configuration.h
+++ b/config/examples/Creality/Ender-5 S1/Configuration.h
@@ -2704,8 +2704,8 @@
  *
  * :{ 'en':'English', 'an':'Aragonese', 'bg':'Bulgarian', 'ca':'Catalan', 'cz':'Czech', 'da':'Danish', 'de':'German', 'el':'Greek (Greece)', 'el_CY':'Greek (Cyprus)', 'es':'Spanish', 'eu':'Basque-Euskera', 'fi':'Finnish', 'fr':'French', 'gl':'Galician', 'hr':'Croatian', 'hu':'Hungarian', 'it':'Italian', 'jp_kana':'Japanese', 'ko_KR':'Korean (South Korea)', 'nl':'Dutch', 'pl':'Polish', 'pt':'Portuguese', 'pt_br':'Portuguese (Brazilian)', 'ro':'Romanian', 'ru':'Russian', 'sk':'Slovak', 'sv':'Swedish', 'tr':'Turkish', 'uk':'Ukrainian', 'vi':'Vietnamese', 'zh_CN':'Chinese (Simplified)', 'zh_TW':'Chinese (Traditional)' }
  */
-#define LCD_LANGUAGE zh_CN
-#define LCD_LANGUAGE_2 en
+#define LCD_LANGUAGE en
+#define LCD_LANGUAGE_2 zh_CN
 
 /**
  * LCD Character Set


### PR DESCRIPTION
### Description

Flip Ender-5 S1 languages so English is the primary language.

> [!NOTE]  
> **I know this printer is still pending support in https://github.com/MarlinFirmware/Marlin/pull/25382.**

There's still an error with the languages as they are now (before this PR), so there is likely a bug in the upstream sanity check since these language defines _are_ different:

`LCD_LANGUAGE_2 (en) cannot be the same as LCD_LANGUAGE.`

With the change in this PR, this config will now fail with the following (expected) error:

```prolog
Marlin/src/gcode/ota/M936.cpp:30:12: fatal error: ../../lcd/rts/lcd_rts.h: No such file or directory
   30 |   #include "../../lcd/rts/lcd_rts.h"
```

### Benefits

English will be the default language for this config.

### Related Issues

- https://github.com/MarlinFirmware/Configurations/issues/1086
- https://github.com/MarlinFirmware/Marlin/pull/25382
