### PR TITLE
🩹 Fix Creality CR-10 S5 with BTT SKR Mini E3 V3 config

### DIFF
--- a/config/examples/Creality/CR-10 S5/BigTreeTech SKR Mini E3 v3/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 S5/BigTreeTech SKR Mini E3 v3/Configuration_adv.h
@@ -1114,6 +1114,7 @@
    *   M5_CW = M3 Clockwise, M5_CCW = M5 Counter-Clockwise
    *
    * :{'M3_CW':'M3 Clockwise','M3_CCW':'M3 Counter-Clockwise','M4_CW':'M4 Clockwise','M4_CCW':'M4 Counter-Clockwise','M5_CW':'M5 Clockwise','M5_CCW':'M5 Counter-Clockwise'}
+   */
   #define TRAMMING_SCREW_THREAD M4_CW // CR-10 S5 config
 
 #endif


### PR DESCRIPTION
### Description

Fix compile issue due to malformed comment block:

<details><summary>error: unterminated #if</summary>
<p>

```prolog
Auto Build...
Detected "BigTreeTech SKR Mini E3 V3.0 (STM32G0B0RE / STM32G0B1RE)" | BTT_SKR_MINI_E3_V3_0 (4001).
Selected STM32G0B1RE_btt
Building environment STM32G0B1RE_btt for board BTT_SKR_MINI_E3_V3_0 (4001)...

In file included from buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/MarlinConfigPre-4-adv.h:33,
                 from buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/Conditionals-4-adv.h:32,
                 from buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/MarlinConfigPre.h:30,
                 from buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/MarlinConfigPre-5-post.h:24,
                 from buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/MarlinConfigPre-6-type.h:24,
                 from buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/MarlinConfig.h:28,
                 from buildroot/share/PlatformIO/scripts/common-dependencies.h:29:
buildroot/share/PlatformIO/scripts/../../../../Marlin/src/inc/../../Configuration_adv.h:1091: error: unterminated #if
 1091 | #if ENABLED(ASSISTED_TRAMMING)
      | 
Error: Failed to parse Marlin features. See previous error messages.
======================================== [FAILED] Took 1.45 seconds ========================================

Environment      Status    Duration
---------------  --------  ------------
STM32G0B1RE_btt  FAILED    00:00:01.448
================================== 1 failed, 0 succeeded in 00:00:01.448 ==================================
Failed
```

</p>
</details>

### Related Isssues
- #1101
- e02a649