### PR TITLE
📝 [WIP] Clarify TJC display support

### DIFF
--- a/config/examples/Creality/Ender-3 S1/LCD Files/README.md
+++ b/config/examples/Creality/Ender-3 S1/LCD Files/README.md
@@ -1,7 +1,5 @@
 # Ender-3 S1 display update guide
 
-Starting with Ender-3 V2, the Ender-3 series **knob**-based (_not_ touch screens) color LCD screens share the same update procedure, with the only difference being the files that need to be copied to a microSD card, based on the type of display unit mainboard.
+Starting with the Ender-3 V2, Creality introduced a series of color LCDs that use a **click-wheel** (but _not_ a touch screen). These displays can connect to any board with an EXP adapter and they all share the same basic update procedure. Different mainboards will require different files to be copied to the microSD card, but after that you just insert it into the display for flashing.
 
-Please refer to the `README` document for the complete procedure and display variant compatibility list, available here:
-
-`../config/examples/Creality/Ender-3 V2/LCD Files`
+See the `Creality/Ender-3 V2/README.md` file for the complete update procedure and information on display compatibility.

--- a/config/examples/Creality/Ender-3 V2 Neo/LCD Files/README.md
+++ b/config/examples/Creality/Ender-3 V2 Neo/LCD Files/README.md
@@ -2,6 +2,4 @@
 
 Starting with Ender-3 V2, the Ender-3 series **knob**-based (_not_ touch screens) color LCD screens share the same update procedure, with the only difference being the files that need to be copied to a microSD card, based on the type of display unit mainboard.
 
-Please refer to the `README` document for the complete procedure and display variant compatibility list, available here:
-
-`../config/examples/Creality/Ender-3 V2/LCD Files`
+See the `Creality/Ender-3 V2/README.md` file for the complete update procedure and display variant compatibility list.

--- a/config/examples/Creality/Ender-3 V2 Neo/LCD Files/README.md
+++ b/config/examples/Creality/Ender-3 V2 Neo/LCD Files/README.md
@@ -1,0 +1,7 @@
+# Ender-3 V2 Neo display update guide
+
+Starting with Ender-3 V2, the Ender-3 series **knob**-based (_not_ touch screens) color LCD screens share the same update procedure, with the only difference being the files that need to be copied to a microSD card, based on the type of display unit mainboard.
+
+Please refer to the `README` document for the complete procedure and display variant compatibility list, available here:
+
+`../config/examples/Creality/Ender-3 V2/LCD Files`

--- a/config/examples/Creality/Ender-3 V2 Neo/LCD Files/README.md
+++ b/config/examples/Creality/Ender-3 V2 Neo/LCD Files/README.md
@@ -1,5 +1,5 @@
 # Ender-3 V2 Neo display update guide
 
-Starting with Ender-3 V2, the Ender-3 series **knob**-based (_not_ touch screens) color LCD screens share the same update procedure, with the only difference being the files that need to be copied to a microSD card, based on the type of display unit mainboard.
+Starting with the Ender-3 V2, Creality introduced a series of color LCDs that use a **click-wheel** (but _not_ a touch screen). These displays can connect to any board with an EXP adapter and they all share the same basic update procedure. Different mainboards will require different files to be copied to the microSD card, but after that you just insert it into the display for flashing.
 
-See the `Creality/Ender-3 V2/README.md` file for the complete update procedure and display variant compatibility list.
+See the `Creality/Ender-3 V2/README.md` file for the complete update procedure and information on display compatibility.

--- a/config/examples/Creality/Ender-3 V2/README.md
+++ b/config/examples/Creality/Ender-3 V2/README.md
@@ -40,7 +40,7 @@ Use the following pictures to identify your type of display unit:
 
     There is currently no information regarding how to compile a firmware for this type of display, nor does it look like there are any official firmwares to attempt a decompilation effort.
 
-* **TJC display** **`Currently undocumented`**, **`Currently incompatible with custom UIs`**
+* **TJC display** **`Undocumented & mostly unsupported due to missing graphics`**
 
     ![Ender3V2S1-TJC](https://user-images.githubusercontent.com/2745567/206931166-24185525-e377-472e-9bed-37a39aab24fb.jpg)
 
@@ -74,17 +74,17 @@ The differences between the types of displays units shown above make them more c
         * Lack of custom graphics assets compilation means no icons are visible
     * ❔ MarlinUI Landscape
 * **TJC**
-    * ✅ Creality UI
+    * ❌ Creality UI
     * ❌ MRiscoC Pro UI
         * As reported by author; incompatibility causes currently unknown
-    * ❔ JyersUI
+    * ❌ JyersUI
     * ⚠️ MarlinUI Portrait
         * Lack of custom graphics assets compilation means no icons are visible
-    * ❔ MarlinUI Landscape
+    * ⚠️ MarlinUI Landscape
 
 ## **If you've got a currently undocumented display**
 
-In the case of **SYNWIT / VIEWE** and **TJC** displays, currently only the Creality UI interface option (`DWIN_CREALITY_LCD`) is fully compatible.
+In the case of **SYNWIT / VIEWE** displays, currently only the Creality UI interface option (`DWIN_CREALITY_LCD`) is fully compatible.
 
 If you have a **DWIN** or **DACAI** display, please follow the procedure below to upgrade the firmware with the custom graphics assets required for MRiscoC Pro UI, JyersUI and MarlinUI.
 


### PR DESCRIPTION
### Description

- TJC displays are mostly unsupported due to missing graphics
- Copy Ender-3 S1 LCD Files README to Ender-3 V2 Neo folder

---

> TJC display (ie what you have) uses TJC_SET/tjc.tft. We cannot generate those files, so there is no screen updates for this display provided by Marlin.

_Originally posted by @ellensp in https://github.com/MarlinFirmware/Marlin/issues/27446#issuecomment-2381421943_

---

### Benefits
Improves documentation for TJC displays

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/27446
