### PR TITLE
Revert "♻️ BTT_SKR_V3_0 => BTT_SKR_3"

### DIFF
--- a/config/examples/Creality/Ender-5 Plus/BigTreeTech SKR 3/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/BigTreeTech SKR 3/Configuration.h
@@ -70,7 +70,7 @@
 
 // Choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_BTT_SKR_3
+  #define MOTHERBOARD BOARD_BTT_SKR_V3_0
 #endif
 
 /**


### PR DESCRIPTION
### Description

This reverts commit 5bb996ada734dd9f4f55c39851cc38dc392e2122.

The `BTT_SKR_V3_0` => `BTT_SKR_3` rename was reverted in https://github.com/MarlinFirmware/Marlin/commit/a66b22c4f16867c345a1256a808437d508485e72 based on the conversation in https://github.com/MarlinFirmware/Marlin/pull/27461#issuecomment-2398497405.

### Benefits

SKR V3.0 config will build / CI tests will pass.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/pull/27461#issuecomment-2398497405
- https://github.com/MarlinFirmware/Marlin/commit/a66b22c4f16867c345a1256a808437d508485e72
- https://github.com/MarlinFirmware/Marlin/commit/3a6bd6920e445a334a95704453ee310bed0c367a
- https://github.com/MarlinFirmware/Configurations/commit/5bb996ada734dd9f4f55c39851cc38dc392e2122

