### PR TITLE
Add TFT_SHARED_IO to Kingroon KP3S Example

### DIFF
--- a/config/examples/Kingroon/KP3S/Configuration.h
+++ b/config/examples/Kingroon/KP3S/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(carloslockward)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(@AR1972)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine

--- a/config/examples/Kingroon/KP3S/Configuration.h
+++ b/config/examples/Kingroon/KP3S/Configuration.h
@@ -63,7 +63,7 @@
 // @section info
 
 // Author info of this build printed to the host during boot and M115
-#define STRING_CONFIG_H_AUTHOR "(kubik369)" // Who made the changes.
+#define STRING_CONFIG_H_AUTHOR "(carloslockward)" // Who made the changes.
 //#define CUSTOM_VERSION_FILE Version.h // Path from the root directory (no quotes)
 
 // @section machine
@@ -3459,7 +3459,7 @@
    */
   #define TFT_THEME BLACK_MARLIN
 
-  //#define TFT_SHARED_IO   // I/O is shared between TFT display and other devices. Disable async data transfer.
+  #define TFT_SHARED_IO   // I/O is shared between TFT display and other devices. Disable async data transfer.
 
   #define COMPACT_MARLIN_BOOT_LOGO  // Use compressed data to save Flash space
 #endif


### PR DESCRIPTION
### Description

The Kingroon KP3S and other MKS ROBIN NANO based printers have been having issues with SD card prints for a couple of versions of Marlin. I have been trying different configs to see if the issue could be solved. After a lot of attempts I discovered that `TFT_SHARED_IO` seems to fix the issues. It would seem that the TFT and the SD card are sharing I/O. Therefore, this should be enabled in the example config.

We should also consider adding this to other examples of MKS ROBIN NANO based printers. But it should probably be on a case by case basis.

### Benefits

Without this config enabled the printer would refuse to print(go back to info screen and do nothing), freeze right before printing or freeze mid print(depending on the  Marlin version used)

### Related Issues

[[BUG] SD Card is detected but doesn't start printing or heating](https://github.com/MarlinFirmware/Marlin/issues/26913)
[[BUG] On Print Start from SD Card Print Never Starts](https://github.com/MarlinFirmware/Marlin/issues/26231)
