### PR TITLE
🐛🚸 BIQU BX Fixes & Improvements

### DIFF
--- a/config/examples/BIQU/BX/Configuration.h
+++ b/config/examples/BIQU/BX/Configuration.h
@@ -1423,7 +1423,7 @@
 //#define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 
 // Force the use of the probe for Z-axis homing
-#define USE_PROBE_FOR_Z_HOMING
+//#define USE_PROBE_FOR_Z_HOMING
 
 /**
  * Z_MIN_PROBE_PIN
@@ -2358,7 +2358,7 @@
  * - Allows Z homing only when XY positions are known and trusted.
  * - If stepper drivers sleep, XY homing may be required again before Z homing.
  */
-#define Z_SAFE_HOMING
+//#define Z_SAFE_HOMING
 
 #if ENABLED(Z_SAFE_HOMING)
   #define Z_SAFE_HOMING_X_POINT X_CENTER  // (mm) X point for Z homing

--- a/config/examples/BIQU/BX/Configuration.h
+++ b/config/examples/BIQU/BX/Configuration.h
@@ -2833,7 +2833,7 @@
 // Add individual axis homing items (Home X, Home Y, and Home Z) to the LCD menu.
 //
 #define INDIVIDUAL_AXIS_HOMING_MENU
-//#define INDIVIDUAL_AXIS_HOMING_SUBMENU
+#define INDIVIDUAL_AXIS_HOMING_SUBMENU
 
 //
 // SPEAKER/BUZZER

--- a/config/examples/BIQU/BX/Configuration_adv.h
+++ b/config/examples/BIQU/BX/Configuration_adv.h
@@ -936,7 +936,7 @@
 #define HOMING_BACKOFF_POST_MM { 2, 2, 2 }    // (linear=mm, rotational=°) Backoff from endstops after homing
 //#define XY_COUNTERPART_BACKOFF_MM 0         // (mm) Backoff X after homing Y, and vice-versa
 
-#define QUICK_HOME                            // If G28 contains XY do a diagonal move first
+//#define QUICK_HOME                          // If G28 contains XY do a diagonal move first
 //#define HOME_Y_BEFORE_X                     // If G28 contains XY home Y before X
 //#define HOME_Z_FIRST                        // Home Z first. Requires a real endstop (not a probe).
 //#define CODEPENDENT_XY_HOMING               // If X/Y can't home without homing Y/X first

--- a/config/examples/BIQU/BX/Configuration_adv.h
+++ b/config/examples/BIQU/BX/Configuration_adv.h
@@ -1208,20 +1208,20 @@
 //#define INPUT_SHAPING_Z
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z)
   #if ENABLED(INPUT_SHAPING_X)
-    #define SHAPING_FREQ_X  37.0        // (Hz) The default dominant resonant frequency on the X axis.
+    #define SHAPING_FREQ_X   0.0        // (Hz) The default dominant resonant frequency on the X axis.
     #define SHAPING_ZETA_X   0.15       // Damping ratio of the X axis (range: 0.0 = no damping to 1.0 = critical damping).
   #endif
   #if ENABLED(INPUT_SHAPING_Y)
-    #define SHAPING_FREQ_Y  37.0        // (Hz) The default dominant resonant frequency on the Y axis.
+    #define SHAPING_FREQ_Y   0.0        // (Hz) The default dominant resonant frequency on the Y axis.
     #define SHAPING_ZETA_Y   0.15       // Damping ratio of the Y axis (range: 0.0 = no damping to 1.0 = critical damping).
   #endif
   #if ENABLED(INPUT_SHAPING_Z)
     #define SHAPING_FREQ_Z  40.0        // (Hz) The default dominant resonant frequency on the Z axis.
     #define SHAPING_ZETA_Z   0.15       // Damping ratio of the Z axis (range: 0.0 = no damping to 1.0 = critical damping).
   #endif
-  //#define SHAPING_MIN_FREQ  20.0      // (Hz) By default the minimum of the shaping frequencies. Override to affect SRAM usage.
+  #define SHAPING_MIN_FREQ  20.0        // (Hz) By default the minimum of the shaping frequencies. Override to affect SRAM usage.
   //#define SHAPING_MAX_STEPRATE 10000  // By default the maximum total step rate of the shaped axes. Override to affect SRAM usage.
-  //#define SHAPING_MENU                // Add a menu to the LCD to set shaping parameters.
+  #define SHAPING_MENU                  // Add a menu to the LCD to set shaping parameters.
 #endif
 
 // @section motion


### PR DESCRIPTION
### Description

#### Fix BIQU BX Z Homing 
A stock BIQU BX homes with a Z limit switch, not the probe. See the README for details on what users can do if they prefer to home with a probe:

https://github.com/MarlinFirmware/Configurations/blob/4bcabd685f851653883e456f3fdaf2bd0a058db6/config/examples/BIQU/BX/README.md?plain=1#L9-L11

While homing with a probe may be preferred, we should not be making this decision for users since they'd need to mod their stock machine.

---

#### Sensorless homing fixes/improvements
- `INDIVIDUAL_AXIS_HOMING_SUBMENU` allows easier tuning of X & Y sensorless homing values via LCD.
- Sensorless homing with `QUICK_HOME` is not consistent. This has been an issue for many years: https://github.com/MarlinFirmware/Marlin/pull/17084

---

####  Better Input Shaping defaults
- Users need to tune IS for their machine

### Benefits

Fix config so it works for a stock machine & revert/improve recent changes