### PR TITLE
Lower default PREHEAT_2_TEMP_HOTEND

### DIFF
--- a/config/examples/Creality/CR-10S/CrealityV1/Configuration.h
+++ b/config/examples/Creality/CR-10S/CrealityV1/Configuration.h
@@ -2252,7 +2252,7 @@
 #define PREHEAT_1_FAN_SPEED     0 // Value from 0 to 255
 
 #define PREHEAT_2_LABEL       "ABS"
-#define PREHEAT_2_TEMP_HOTEND 250
+#define PREHEAT_2_TEMP_HOTEND 235
 #define PREHEAT_2_TEMP_BED    80
 #define PREHEAT_2_TEMP_CHAMBER 35
 #define PREHEAT_2_FAN_SPEED     0 // Value from 0 to 255


### PR DESCRIPTION
Decrease PREHEAT_2_TEMP_HOTEND from 250 to 235 to satisfy assertion at temperature.cpp:314:38 (PREHEAT_2_TEMP_HOTEND must be less than HEATER_0_MAXTEMP - 15)

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

The Creality CR-10S example config doesn't compile on Marlin 2.1.2.4 due to a failing assertion at compile time. This is due to PREHEAT_2_TEMP_HOTEND being too high. This PR lowers its default value to satisfy the assertion.

### Benefits

Enables compilation of Marlin 2.1.2.4 when using the example Creality CR-10S config file.

### Related Issues

While I couldn't find a specific bug for this on github, the following threads refer to this issue:
- https://marlin.crc.id.au/forum/t/cr10s-s5-builder-bug/1614/2
- https://github.com/MarlinFirmware/Marlin/issues/27245
