### PR TITLE
🚸 Editable homing for Prusa MK3 with BTT002

### DIFF
--- a/config/examples/Prusa/MK3S-BigTreeTech-BTT002/Configuration.h
+++ b/config/examples/Prusa/MK3S-BigTreeTech-BTT002/Configuration.h
@@ -2399,7 +2399,7 @@
 #define HOMING_FEEDRATE_MM_M { (50*60), (50*60), (5*60) }
 
 // Edit homing feedrates with M210 and MarlinUI menu items
-//#define EDITABLE_HOMING_FEEDRATE
+#define EDITABLE_HOMING_FEEDRATE
 
 // Validate that endstops are triggered on homing moves
 #define VALIDATE_HOMING_ENDSTOPS

--- a/config/examples/Prusa/MK3S-BigTreeTech-BTT002/Configuration_adv.h
+++ b/config/examples/Prusa/MK3S-BigTreeTech-BTT002/Configuration_adv.h
@@ -3000,7 +3000,7 @@
 
   #define HOLD_MULTIPLIER    0.5  // Scales down the holding current from run current
 
-  //#define EDITABLE_HOMING_CURRENT   // Add a G-code and menu to modify the Homing Current
+  #define EDITABLE_HOMING_CURRENT     // Add a G-code and menu to modify the Homing Current
 
   /**
    * Interpolate microsteps to 256


### PR DESCRIPTION
### Description

Enable editable homing settings for Prusa MK3 with BTT002. 

### Benefits

This will be in line with the other Prusa MK3 config / allow easier tuning of sensorless homing settings.

### Related Issues

I was actually preparing a PR for sensorless homing configs, but thinkyhead beat me to it:
- https://github.com/MarlinFirmware/Configurations/commit/897e7859b43bc9707fd9d432492fb60dac8ed878
