### PR TITLE
Fix babysteps and baudrate

### DIFF
--- a/config/examples/BIBO/TouchX/default - BLTouch/Configuration.h
+++ b/config/examples/BIBO/TouchX/default - BLTouch/Configuration.h
@@ -96,7 +96,7 @@
  *
  * :[2400, 9600, 19200, 38400, 57600, 115200, 250000, 500000, 1000000]
  */
-#define BAUDRATE 250000
+#define BAUDRATE 115200
 
 //#define BAUD_RATE_GCODE     // Enable G-code M575 to set the baud rate
 

--- a/config/examples/BIBO/TouchX/default - BLTouch/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/default - BLTouch/Configuration_adv.h
@@ -2293,13 +2293,13 @@
  *
  * Warning: Does not respect endstops!
  */
-//#define BABYSTEPPING
+#define BABYSTEPPING
 #if ENABLED(BABYSTEPPING)
   //#define EP_BABYSTEPPING                 // M293/M294 babystepping with EMERGENCY_PARSER support
   //#define BABYSTEP_WITHOUT_HOMING
   //#define BABYSTEP_ALWAYS_AVAILABLE       // Allow babystepping at all times (not just during movement)
   //#define BABYSTEP_XY                     // Also enable X/Y Babystepping. Not supported on DELTA!
-  //#define BABYSTEP_INVERT_Z               // Enable if Z babysteps should go the other way
+  #define BABYSTEP_INVERT_Z               // Enable if Z babysteps should go the other way
   //#define BABYSTEP_MILLIMETER_UNITS       // Specify BABYSTEP_MULTIPLICATOR_(XY|Z) in mm instead of micro-steps
   #define BABYSTEP_MULTIPLICATOR_Z  1       // (steps or mm) Steps or millimeter distance for each Z babystep
   #define BABYSTEP_MULTIPLICATOR_XY 1       // (steps or mm) Steps or millimeter distance for each XY babystep
@@ -2314,9 +2314,9 @@
     #endif
   #endif
 
-  //#define BABYSTEP_DISPLAY_TOTAL          // Display total babysteps since last G28
+  #define BABYSTEP_DISPLAY_TOTAL          // Display total babysteps since last G28
 
-  //#define BABYSTEP_ZPROBE_OFFSET          // Combine M851 Z and Babystepping
+  #define BABYSTEP_ZPROBE_OFFSET          // Combine M851 Z and Babystepping
   //#define BABYSTEP_GLOBAL_Z               // Combine M424 Z and Babystepping
 
   #if ANY(BABYSTEP_ZPROBE_OFFSET, BABYSTEP_GLOBAL_Z)

--- a/config/examples/BIBO/TouchX/default - BLTouch/README.md
+++ b/config/examples/BIBO/TouchX/default - BLTouch/README.md
@@ -2,5 +2,14 @@ Note: Users with factory mks tf28 screens will need to modify the screen baudrat
 The factory baudrate of 250000 causes problems with gcode items which report back information like M114. 
 Using 115200 on both the mainboard and the screen resolves this issue.
 
-Change the mks_config.txt configuration file baudrate to cfg_baud_rate:3
-This will set the correct baudrate for the screen to match the main board
+Change the mks_config.txt configuration file for BLTouch and correct baud rate
+
+set baudrate to 115200
+cfg_baud_rate:3
+
+enable auto leveling
+cfg_leveling_mode:1
+cfg_auto_leveling_cmd:G28;G29;
+
+Enable function of babysteps.
+cfg_babystep_btn_display:1

--- a/config/examples/BIBO/TouchX/default - BLTouch/README.md
+++ b/config/examples/BIBO/TouchX/default - BLTouch/README.md
@@ -1,15 +1,19 @@
-Note: Users with factory mks tf28 screens will need to modify the screen baudrate to 115200. 
-The factory baudrate of 250000 causes problems with gcode items which report back information like M114. 
+#Important User Note: 
+Users with factory MKS TFT28 screens will need to modify the screen baudrate to 115200. 
+The factory baudrate of 250000 causes problems with gcode items that report back information like M114. 
 Using 115200 on both the mainboard and the screen resolves this issue.
 
-Change the mks_config.txt configuration file for BLTouch and correct baud rate
+Change the mks_config.txt configuration file for BLTouch and correct the baud rate, set auto leveling, and enable babysteps
+Link to MKS TFT28 screen firmware
+https://github.com/makerbase-mks/MKS-TFT/tree/master/MKS-TFT2.8-3.2
 
-set baudrate to 115200
-cfg_baud_rate:3
+Important mks_config.txt configuration changes
+- set baudrate to 115200
+  - cfg_baud_rate:3
 
-enable auto leveling
-cfg_leveling_mode:1
-cfg_auto_leveling_cmd:G28;G29;
+- Enable auto leveling
+  - cfg_leveling_mode:1
+  - cfg_auto_leveling_cmd:G28;G29;
 
-Enable function of babysteps.
-cfg_babystep_btn_display:1
+- Enable function of babysteps.
+  - cfg_babystep_btn_display:1

--- a/config/examples/BIBO/TouchX/default - BLTouch/README.md
+++ b/config/examples/BIBO/TouchX/default - BLTouch/README.md
@@ -1,4 +1,5 @@
-#Important User Note: 
+# Important User Note:
+
 Users with factory MKS TFT28 screens will need to modify the screen baudrate to 115200. 
 The factory baudrate of 250000 causes problems with gcode items that report back information like M114. 
 Using 115200 on both the mainboard and the screen resolves this issue.
@@ -7,7 +8,7 @@ Change the mks_config.txt configuration file for BLTouch and correct the baud ra
 Link to MKS TFT28 screen firmware
 https://github.com/makerbase-mks/MKS-TFT/tree/master/MKS-TFT2.8-3.2
 
-Important mks_config.txt configuration changes
+### Important mks_config.txt configuration changes
 - set baudrate to 115200
   - cfg_baud_rate:3
 

--- a/config/examples/BIBO/TouchX/default - BLTouch/README.md
+++ b/config/examples/BIBO/TouchX/default - BLTouch/README.md
@@ -1,0 +1,6 @@
+Note: Users with factory mks tf28 screens will need to modify the screen baudrate to 115200. 
+The factory baudrate of 250000 causes problems with gcode items which report back information like M114. 
+Using 115200 on both the mainboard and the screen resolves this issue.
+
+Change the mks_config.txt configuration file baudrate to cfg_baud_rate:3
+This will set the correct baudrate for the screen to match the main board


### PR DESCRIPTION
### Description

This patch corrects two issues which cause significant issues in setup and tuning of a BIBO printer.

1. enables babysteps which are needed for bltouch z-position corrections
2. baudrate was corrected to 115200

### Benefits

fixes inability to adjust z position when using bltouch as babysteps were not enabled
Fixes issues where M114 would not report the printer position due to baudrate being above 115200

Note: Users with factory mks tf28 screens will need to modify the screen baudrate to 115200. The factory baudrate of 250000 causes problems with gcode items which report back information like M114. Using 115200 on both the mainboard and the screen resolves this issue.
