### PR TITLE
update BIBO BLtouch settings

### DIFF
--- a/config/examples/BIBO/TouchX/default - BLTouch/Configuration.h
+++ b/config/examples/BIBO/TouchX/default - BLTouch/Configuration.h
@@ -1668,7 +1668,7 @@
 
 // Most probes should stay away from the edges of the bed, but
 // with NOZZLE_AS_PROBE this can be negative for a wider probing area.
-#define PROBING_MARGIN 10
+#define PROBING_MARGIN 13
 
 // X and Y axis travel speed between probes.
 // Leave undefined to use the average of the current XY homing feedrate.
@@ -2213,8 +2213,8 @@
 #if ANY(AUTO_BED_LEVELING_LINEAR, AUTO_BED_LEVELING_BILINEAR)
 
   // Set the number of grid points per dimension.
-  #define GRID_MAX_POINTS_X 8
-  #define GRID_MAX_POINTS_Y GRID_MAX_POINTS_X
+  #define GRID_MAX_POINTS_X 3
+  #define GRID_MAX_POINTS_Y 5
 
   // Probe along the Y axis, advancing X after each column
   //#define PROBE_Y_FIRST


### PR DESCRIPTION
### Description

update probing grid to 3x5 for this 214x186mm bed which is a similar density of probing points seen on a 250 x 210mm bed at 4x6 points. This should greatly speed up probing over the 8x8 grid

reduce margins a little on probing. at 10mm margins the print carriage would hit the x and y end stops during probing. using a 13mm margin should resolve these collisions.

### Benefits

-speed up probing process with more reasonable probing density
-correct issue of collisions with endstops during probing.
