### PR TITLE
Correct Hotend Offset Axis for Replicator Dual

### DIFF
--- a/config/examples/MakerBot/Replicator Dual/Configuration.h
+++ b/config/examples/MakerBot/Replicator Dual/Configuration.h
@@ -385,8 +385,8 @@
 // Offset of the extruders (uncomment if using more than one and relying on firmware to position when changing).
 // The offset has to be X=0, Y=0 for the extruder 0 hotend (default extruder).
 // For the other hotends it is their distance from the extruder 0 hotend.
-//#define HOTEND_OFFSET_X { 0.0, 20.00 } // (mm) relative X-offset for each nozzle
-#define HOTEND_OFFSET_Y { 0.0, -33.00 }  // (mm) relative Y-offset for each nozzle
+#define HOTEND_OFFSET_X { 0.0, -33.00 }  // (mm) relative X-offset for each nozzle
+//#define HOTEND_OFFSET_Y { 0.0, 5.00 }  // (mm) relative Y-offset for each nozzle
 //#define HOTEND_OFFSET_Z { 0.0, 0.00 }  // (mm) relative Z-offset for each nozzle
 
 // @section multi-material


### PR DESCRIPTION
### Requirements

Replicator Dual

### Description

Another user discovered I transposed the axis for the hotend offset (Y instead of X) in the original pull request.

### Benefits

Corrects hotend offset for left (secondary) extruder making dual extrusion printing work properly.


