### PR TITLE
update CUSTOM_BOOTSCREEN_BMPWIDTH  in AnimationExample

### DIFF
--- a/config/examples/AnimationExample/_Bootscreen.h
+++ b/config/examples/AnimationExample/_Bootscreen.h
@@ -38,7 +38,7 @@
 #define CUSTOM_BOOTSCREEN_FRAME_TIME 100        // (ms) Same time for all frames
 //#define CUSTOM_BOOTSCREEN_ANIMATED_FRAME_TIME // Each frame also has a duration
 
-#define CUSTOM_BOOTSCREEN_BMPWIDTH   120
+#define CUSTOM_BOOTSCREEN_BMPWIDTH   56
 
 const unsigned char custom_start_bmp[] PROGMEM = {
   B00011111,B11111111,B11111111,B11111111,B11111111,B11111111,B11111111,


### PR DESCRIPTION
### Requirements

REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER (or other 128x64 mono lcd screen) 
SHOW_CUSTOM_BOOTSCREEN
Use config/examples/AnimationExample/_Bootscreen.h 

### Description

The example _Bootscreen.h incorrectly sets CUSTOM_BOOTSCREEN_BMPWIDTH 120 when there is only 56 bits of data

This causes the animation to be scrambled

Updated to 56

### Benefits

Example amamated bootscreen works as expected

### Related Issues
I noticed while helping out discord user with their own animated bootscreen 
