### PR TITLE
Changed Tramming Distance to Measurements Ender 2 Pro

### DIFF
--- a/config/examples/Creality/Ender-2 Pro/CrealityV24S4/Configuration.h
+++ b/config/examples/Creality/Ender-2 Pro/CrealityV24S4/Configuration.h
@@ -2362,7 +2362,7 @@
 //#define LCD_BED_TRAMMING
 
 #if ENABLED(LCD_BED_TRAMMING)
-  #define BED_TRAMMING_INSET_LFRB { 30, 30, 30, 30 } // (mm) Left, Front, Right, Back insets
+  #define BED_TRAMMING_INSET_LFRB { 27, 37, 28, 34 } // (mm) Left, Front, Right, Back insets
   #define BED_TRAMMING_HEIGHT      0.0        // (mm) Z height of nozzle at tramming points
   #define BED_TRAMMING_Z_HOP       4.0        // (mm) Z raise between tramming points
   //#define BED_TRAMMING_INCLUDE_CENTER       // Move to the center after the last corner

--- a/config/examples/Creality/Ender-2 Pro/CrealityV423/Configuration.h
+++ b/config/examples/Creality/Ender-2 Pro/CrealityV423/Configuration.h
@@ -2362,7 +2362,7 @@
 //#define LCD_BED_TRAMMING
 
 #if ENABLED(LCD_BED_TRAMMING)
-  #define BED_TRAMMING_INSET_LFRB { 30, 30, 30, 30 } // (mm) Left, Front, Right, Back insets
+  #define BED_TRAMMING_INSET_LFRB { 27, 37, 28, 34 } // (mm) Left, Front, Right, Back insets
   #define BED_TRAMMING_HEIGHT      0.0        // (mm) Z height of nozzle at tramming points
   #define BED_TRAMMING_Z_HOP       4.0        // (mm) Z raise between tramming points
   //#define BED_TRAMMING_INCLUDE_CENTER       // Move to the center after the last corner


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

This Pull Request changes the tramming distance to the distance of the bed springs from the edge. 
It was measured and validated by compiling and testing the values on the Ender 2 Pro printer. 

### Benefits

<!-- What does this fix or improve? -->
This Pull Request makes tramming the bed easier, because the nozzle moves exactly from spring to spring, where the screws to adjust the bed height are located. 

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
