### PR TITLE
Wanhao D9: Fix INVERT_E0_DIR for MK1 and INVERT_Y_DIR for MK2/500 based on owner feedback

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Check out the PR
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     # Get the list of directories containing changed config files:
     - name: Get changed directories
@@ -44,7 +44,7 @@ jobs:
         echo -e "DIRS<<EOF\n$DIRS\nEOF" >>$GITHUB_ENV
 
     - name: Cache pip
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
@@ -52,7 +52,7 @@ jobs:
           ${{ runner.os }}-pip-
 
     - name: Cache PlatformIO
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.platformio

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Check out
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0  # Fetch all history for all branches and tags
         token: ${{ secrets.GITHUB_TOKEN }}  # Use the built-in token for authentication

--- a/config/examples/Wanhao/Duplicator 9/MK1/300/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 9/MK1/300/Configuration.h
@@ -1891,7 +1891,7 @@
 //#define INVERT_W_DIR false
 
 // For direct drive extruder v9 set to true, for geared extruder set to false.
-#define INVERT_E0_DIR true
+#define INVERT_E0_DIR false
 #define INVERT_E1_DIR false
 #define INVERT_E2_DIR false
 #define INVERT_E3_DIR false

--- a/config/examples/Wanhao/Duplicator 9/MK1/400/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 9/MK1/400/Configuration.h
@@ -1891,7 +1891,7 @@
 //#define INVERT_W_DIR false
 
 // For direct drive extruder v9 set to true, for geared extruder set to false.
-#define INVERT_E0_DIR true
+#define INVERT_E0_DIR false
 #define INVERT_E1_DIR false
 #define INVERT_E2_DIR false
 #define INVERT_E3_DIR false

--- a/config/examples/Wanhao/Duplicator 9/MK1/500/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 9/MK1/500/Configuration.h
@@ -1891,7 +1891,7 @@
 //#define INVERT_W_DIR false
 
 // For direct drive extruder v9 set to true, for geared extruder set to false.
-#define INVERT_E0_DIR true
+#define INVERT_E0_DIR false
 #define INVERT_E1_DIR false
 #define INVERT_E2_DIR false
 #define INVERT_E3_DIR false

--- a/config/examples/Wanhao/Duplicator 9/MK2/500/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 9/MK2/500/Configuration.h
@@ -1881,7 +1881,7 @@
 
 // Invert the stepper direction. Change (or reverse the motor connector) if an axis goes the wrong way.
 #define INVERT_X_DIR true
-#define INVERT_Y_DIR false
+#define INVERT_Y_DIR true
 #define INVERT_Z_DIR false
 //#define INVERT_I_DIR false
 //#define INVERT_J_DIR false


### PR DESCRIPTION
### Description
Fix stepper direction settings for Wanhao Duplicator 9 configurations based on
feedback from multiple machine owners who validated the corrected values on their
hardware.

Changes:
- D9/MK1/300, 400, 500: `INVERT_E0_DIR` changed from `true` to `false`
  (direct drive extruder v9 requires false, not true as previously documented)
- D9/MK2/500: `INVERT_Y_DIR` changed from `false` to `true`

### Benefits
Prevents extruder running in reverse direction out of the box on D9 MK1 variants,
and fixes Y axis direction on D9 MK2/500.

### Related Issues
Reported and validated by Wanhao D9 owners.