### PR TITLE
Ender 5 Plus Configs - Increase Mesh Inset

### DIFF
--- a/config/examples/Creality/Ender-5 Plus/BigTreeTech SKR 3/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/BigTreeTech SKR 3/Configuration.h
@@ -2296,7 +2296,7 @@
 
   //#define MESH_EDIT_GFX_OVERLAY   // Display a graphics overlay while editing the mesh
 
-  #define MESH_INSET 45              // Set Mesh bounds as an inset region of the bed
+  #define MESH_INSET  1             // Set Mesh bounds as an inset region of the bed
   #define GRID_MAX_POINTS_X 5       // Don't use more than 15 points per axis, implementation limited.
   #define GRID_MAX_POINTS_Y GRID_MAX_POINTS_X
 

--- a/config/examples/Creality/Ender-5 Plus/BigTreeTech SKR 3/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/BigTreeTech SKR 3/Configuration.h
@@ -2296,7 +2296,7 @@
 
   //#define MESH_EDIT_GFX_OVERLAY   // Display a graphics overlay while editing the mesh
 
-  #define MESH_INSET 1              // Set Mesh bounds as an inset region of the bed
+  #define MESH_INSET 45              // Set Mesh bounds as an inset region of the bed
   #define GRID_MAX_POINTS_X 5       // Don't use more than 15 points per axis, implementation limited.
   #define GRID_MAX_POINTS_Y GRID_MAX_POINTS_X
 

--- a/config/examples/Creality/Ender-5 Plus/BigTreeTech SKR 3/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 Plus/BigTreeTech SKR 3/Configuration_adv.h
@@ -2538,8 +2538,8 @@
   // Override the mesh area if the automatic (max) area is too large
   #define MESH_MIN_X MESH_INSET
   #define MESH_MIN_Y MESH_INSET
-  #define MESH_MAX_X X_BED_SIZE - (MESH_INSET)
-  #define MESH_MAX_Y Y_BED_SIZE - (MESH_INSET)
+  #define MESH_MAX_X (X_BED_SIZE - 44 - (MESH_INSET))
+  #define MESH_MAX_Y (Y_BED_SIZE -  5 - (MESH_INSET))
 #endif
 
 #if ALL(AUTO_BED_LEVELING_UBL, EEPROM_SETTINGS)

--- a/config/examples/Creality/Ender-5 Plus/Creality 4.2.2 (RELOADED UI)/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/Creality 4.2.2 (RELOADED UI)/Configuration.h
@@ -2303,7 +2303,7 @@
 
   //#define MESH_EDIT_GFX_OVERLAY   // Display a graphics overlay while editing the mesh
 
-  #define MESH_INSET 45             // Set Mesh bounds as an inset region of the bed
+  #define MESH_INSET  1             // Set Mesh bounds as an inset region of the bed
   #define GRID_MAX_POINTS_X  5      // Don't use more than 15 points per axis, implementation limited.
   #define GRID_MAX_POINTS_Y GRID_MAX_POINTS_X
 

--- a/config/examples/Creality/Ender-5 Plus/Creality 4.2.2 (RELOADED UI)/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/Creality 4.2.2 (RELOADED UI)/Configuration.h
@@ -2303,7 +2303,7 @@
 
   //#define MESH_EDIT_GFX_OVERLAY   // Display a graphics overlay while editing the mesh
 
-  #define MESH_INSET 15             // Set Mesh bounds as an inset region of the bed
+  #define MESH_INSET 45             // Set Mesh bounds as an inset region of the bed
   #define GRID_MAX_POINTS_X  5      // Don't use more than 15 points per axis, implementation limited.
   #define GRID_MAX_POINTS_Y GRID_MAX_POINTS_X
 

--- a/config/examples/Creality/Ender-5 Plus/Creality 4.2.2 (RELOADED UI)/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 Plus/Creality 4.2.2 (RELOADED UI)/Configuration_adv.h
@@ -2537,8 +2537,8 @@
   // Override the mesh area if the automatic (max) area is too large
   #define MESH_MIN_X MESH_INSET
   #define MESH_MIN_Y MESH_INSET
-  #define MESH_MAX_X X_BED_SIZE - (MESH_INSET)
-  #define MESH_MAX_Y Y_BED_SIZE - (MESH_INSET)
+  #define MESH_MAX_X (X_BED_SIZE - 44 - (MESH_INSET))
+  #define MESH_MAX_Y (Y_BED_SIZE -  5 - (MESH_INSET))
 #endif
 
 #if ALL(AUTO_BED_LEVELING_UBL, EEPROM_SETTINGS)

--- a/config/examples/Creality/Ender-5 Plus/CrealityV1 (ORIGIN UI)/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/CrealityV1 (ORIGIN UI)/Configuration.h
@@ -2306,7 +2306,7 @@
 
   //#define MESH_EDIT_GFX_OVERLAY   // Display a graphics overlay while editing the mesh
 
-  #define MESH_INSET 45             // Set Mesh bounds as an inset region of the bed
+  #define MESH_INSET  1             // Set Mesh bounds as an inset region of the bed
   #define GRID_MAX_POINTS_X  7      // Don't use more than 15 points per axis, implementation limited.
   #define GRID_MAX_POINTS_Y GRID_MAX_POINTS_X
 

--- a/config/examples/Creality/Ender-5 Plus/CrealityV1 (ORIGIN UI)/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/CrealityV1 (ORIGIN UI)/Configuration.h
@@ -2306,7 +2306,7 @@
 
   //#define MESH_EDIT_GFX_OVERLAY   // Display a graphics overlay while editing the mesh
 
-  #define MESH_INSET 15             // Set Mesh bounds as an inset region of the bed
+  #define MESH_INSET 45             // Set Mesh bounds as an inset region of the bed
   #define GRID_MAX_POINTS_X  7      // Don't use more than 15 points per axis, implementation limited.
   #define GRID_MAX_POINTS_Y GRID_MAX_POINTS_X
 

--- a/config/examples/Creality/Ender-5 Plus/CrealityV1 (ORIGIN UI)/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 Plus/CrealityV1 (ORIGIN UI)/Configuration_adv.h
@@ -2538,8 +2538,8 @@
   // Override the mesh area if the automatic (max) area is too large
   #define MESH_MIN_X MESH_INSET
   #define MESH_MIN_Y MESH_INSET
-  #define MESH_MAX_X X_BED_SIZE - (MESH_INSET)
-  #define MESH_MAX_Y Y_BED_SIZE - (MESH_INSET)
+  #define MESH_MAX_X (X_BED_SIZE - 44 - (MESH_INSET))
+  #define MESH_MAX_Y (Y_BED_SIZE -  5 - (MESH_INSET))
 #endif
 
 #if ALL(AUTO_BED_LEVELING_UBL, EEPROM_SETTINGS)

--- a/config/examples/Creality/Ender-5 Plus/CrealityV1 (RELOADED UI)/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/CrealityV1 (RELOADED UI)/Configuration.h
@@ -2306,7 +2306,7 @@
 
   //#define MESH_EDIT_GFX_OVERLAY   // Display a graphics overlay while editing the mesh
 
-  #define MESH_INSET 15             // Set Mesh bounds as an inset region of the bed
+  #define MESH_INSET 45             // Set Mesh bounds as an inset region of the bed
   #define GRID_MAX_POINTS_X  5      // Don't use more than 15 points per axis, implementation limited.
   #define GRID_MAX_POINTS_Y GRID_MAX_POINTS_X
 

--- a/config/examples/Creality/Ender-5 Plus/CrealityV1 (RELOADED UI)/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/CrealityV1 (RELOADED UI)/Configuration.h
@@ -2306,7 +2306,7 @@
 
   //#define MESH_EDIT_GFX_OVERLAY   // Display a graphics overlay while editing the mesh
 
-  #define MESH_INSET 45             // Set Mesh bounds as an inset region of the bed
+  #define MESH_INSET  1             // Set Mesh bounds as an inset region of the bed
   #define GRID_MAX_POINTS_X  5      // Don't use more than 15 points per axis, implementation limited.
   #define GRID_MAX_POINTS_Y GRID_MAX_POINTS_X
 

--- a/config/examples/Creality/Ender-5 Plus/CrealityV1 (RELOADED UI)/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 Plus/CrealityV1 (RELOADED UI)/Configuration_adv.h
@@ -2538,8 +2538,8 @@
   // Override the mesh area if the automatic (max) area is too large
   #define MESH_MIN_X MESH_INSET
   #define MESH_MIN_Y MESH_INSET
-  #define MESH_MAX_X X_BED_SIZE - (MESH_INSET)
-  #define MESH_MAX_Y Y_BED_SIZE - (MESH_INSET)
+  #define MESH_MAX_X (X_BED_SIZE - 44 - (MESH_INSET))
+  #define MESH_MAX_Y (Y_BED_SIZE -  5 - (MESH_INSET))
 #endif
 
 #if ALL(AUTO_BED_LEVELING_UBL, EEPROM_SETTINGS)


### PR DESCRIPTION
As far as I can tell, the Ender 5 Plus configuration.h files have too low of a MESH_INSET.  This causes a couple problems:

### Description

1. UBL probing does not always probe unique bed positions and will probe the same spot more than once.
2. The power cord for the Y-carriage stepper motor is too short for the current MESH_INSET values and will be pulled out of its socket on the motor.

-->

### Benefits

Benefits of this PR include:

1. UBL probes unique locations on the print bed
2. The power cord for the Y-carriage stepper motor doesn't get stretched to the point its plug pulls out of the stepper motor's socket.

### Related Issues

May fix #1106 
