### PR TITLE
fix(Configurations): rename RESONANCE_TEST to FTM_RESONANCE_TEST (411 occurrences)

### DIFF
--- a/config/default/Configuration_adv.h
+++ b/config/default/Configuration_adv.h
@@ -1313,7 +1313,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/3DMatik/XL/Configuration_adv.h
+++ b/config/examples/3DMatik/XL/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/ADIMLab/Gantry v1/Configuration_adv.h
+++ b/config/examples/ADIMLab/Gantry v1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/ADIMLab/Gantry v2/Configuration_adv.h
+++ b/config/examples/ADIMLab/Gantry v2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Alfawise/U20-bltouch/Configuration_adv.h
+++ b/config/examples/Alfawise/U20-bltouch/Configuration_adv.h
@@ -1317,7 +1317,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Alfawise/U20/Configuration_adv.h
+++ b/config/examples/Alfawise/U20/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/AliExpress/CL-260/Configuration_adv.h
+++ b/config/examples/AliExpress/CL-260/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/AliExpress/UM2pExt/Configuration_adv.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Anet/A2/Configuration_adv.h
+++ b/config/examples/Anet/A2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Anet/A2plus/Configuration_adv.h
+++ b/config/examples/Anet/A2plus/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Anet/A6/Configuration_adv.h
+++ b/config/examples/Anet/A6/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Anet/A8/Configuration_adv.h
+++ b/config/examples/Anet/A8/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Anet/A8plus/Configuration_adv.h
+++ b/config/examples/Anet/A8plus/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Anet/A9/Configuration_adv.h
+++ b/config/examples/Anet/A9/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Anet/E10/Configuration_adv.h
+++ b/config/examples/Anet/E10/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Anet/E16/BTT SKR 1.3/Configuration_adv.h
+++ b/config/examples/Anet/E16/BTT SKR 1.3/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Anet/E16/Stock/Configuration_adv.h
+++ b/config/examples/Anet/E16/Stock/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Anet/ET4+/Configuration_adv.h
+++ b/config/examples/Anet/ET4+/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Anet/ET4-Pro/Configuration_adv.h
+++ b/config/examples/Anet/ET4-Pro/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Anet/ET4/Configuration_adv.h
+++ b/config/examples/Anet/ET4/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Anet/ET4X/Configuration_adv.h
+++ b/config/examples/Anet/ET4X/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Anet/ET5-Pro/Configuration_adv.h
+++ b/config/examples/Anet/ET5-Pro/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Anet/ET5/Configuration_adv.h
+++ b/config/examples/Anet/ET5/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Anet/ET5X/Configuration_adv.h
+++ b/config/examples/Anet/ET5X/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/AnyCubic/Chiron/Configuration_adv.h
+++ b/config/examples/AnyCubic/Chiron/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/AnyCubic/Mega Zero 2.0/Anycubic V1/Configuration_adv.h
+++ b/config/examples/AnyCubic/Mega Zero 2.0/Anycubic V1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/AnyCubic/Mega Zero/Anycubic V1/Configuration_adv.h
+++ b/config/examples/AnyCubic/Mega Zero/Anycubic V1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/AnyCubic/Mega Zero/BigTreeTech SKR Mini MZ V1.0/Configuration_adv.h
+++ b/config/examples/AnyCubic/Mega Zero/BigTreeTech SKR Mini MZ V1.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/AnyCubic/Vyper/Configuration_adv.h
+++ b/config/examples/AnyCubic/Vyper/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/AnyCubic/i3 Mega/Trigorilla AVR/Configuration_adv.h
+++ b/config/examples/AnyCubic/i3 Mega/Trigorilla AVR/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/AnyCubic/i3 Mega/Trigorilla Pro STM32/Configuration_adv.h
+++ b/config/examples/AnyCubic/i3 Mega/Trigorilla Pro STM32/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/AnyCubic/i3/Configuration_adv.h
+++ b/config/examples/AnyCubic/i3/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/ArmEd/Configuration_adv.h
+++ b/config/examples/ArmEd/Configuration_adv.h
@@ -1313,7 +1313,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Artillery/Genius Pro/Configuration_adv.h
+++ b/config/examples/Artillery/Genius Pro/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Artillery/Genius/BLTouch/Configuration_adv.h
+++ b/config/examples/Artillery/Genius/BLTouch/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Artillery/Genius/V1/Configuration_adv.h
+++ b/config/examples/Artillery/Genius/V1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Artillery/Hornet/Configuration_adv.h
+++ b/config/examples/Artillery/Hornet/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Artillery/Sidewinder X1/0.9 BMG - E3D V6/Configuration_adv.h
+++ b/config/examples/Artillery/Sidewinder X1/0.9 BMG - E3D V6/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Artillery/Sidewinder X1/V1/Configuration_adv.h
+++ b/config/examples/Artillery/Sidewinder X1/V1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Artillery/Sidewinder X2/Configuration_adv.h
+++ b/config/examples/Artillery/Sidewinder X2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Azteeg/X5GT/Configuration_adv.h
+++ b/config/examples/Azteeg/X5GT/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/BIBO/TouchX/default - BLTouch/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/default - BLTouch/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/BIQU/B1 SE Plus/Configuration_adv.h
+++ b/config/examples/BIQU/B1 SE Plus/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/BIQU/B1 SE/Configuration_adv.h
+++ b/config/examples/BIQU/B1 SE/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/BIQU/B1/Configuration_adv.h
+++ b/config/examples/BIQU/B1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/BIQU/BX/all-metal-hotend/Configuration_adv.h
+++ b/config/examples/BIQU/BX/all-metal-hotend/Configuration_adv.h
@@ -1309,7 +1309,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/BIQU/BX/base/Configuration_adv.h
+++ b/config/examples/BIQU/BX/base/Configuration_adv.h
@@ -1309,7 +1309,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/BIQU/Hurakan/Configuration_adv.h
+++ b/config/examples/BIQU/Hurakan/Configuration_adv.h
@@ -1309,7 +1309,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/BIQU/Thunder Standard/Configuration_adv.h
+++ b/config/examples/BIQU/Thunder Standard/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/CNC/miniRambo/Configuration_adv.h
+++ b/config/examples/CNC/miniRambo/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/CTC/A13/Configuration_adv.h
+++ b/config/examples/CTC/A13/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/CTC/Bizer/Configuration_adv.h
+++ b/config/examples/CTC/Bizer/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/CTC/i3 2560 Rev A/no probe/Configuration_adv.h
+++ b/config/examples/CTC/i3 2560 Rev A/no probe/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Cartesio/Configuration_adv.h
+++ b/config/examples/Cartesio/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Copymaster3D/300/Configuration_adv.h
+++ b/config/examples/Copymaster3D/300/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Copymaster3D/400/Configuration_adv.h
+++ b/config/examples/Copymaster3D/400/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Copymaster3D/500/Configuration_adv.h
+++ b/config/examples/Copymaster3D/500/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10 Max/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 Max/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10 Mini/BigTreeTech SKR Mini E3 2.0/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 Mini/BigTreeTech SKR Mini E3 2.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10 Mini/BigTreeTech SKR Mini E3 3.0/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 Mini/BigTreeTech SKR Mini E3 3.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10 Mini/CrealityV1/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 Mini/CrealityV1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10 Mini/MEEB-3DP/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 Mini/MEEB-3DP/Configuration_adv.h
@@ -1307,7 +1307,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10 S4/CrealityV1/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 S4/CrealityV1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10 S5/BigTreeTech SKR Mini E3 1.2 with TFT35 E3 V3.0/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 S5/BigTreeTech SKR Mini E3 1.2 with TFT35 E3 V3.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10 S5/BigTreeTech SKR Mini E3 v3/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 S5/BigTreeTech SKR Mini E3 v3/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10 S5/CrealityV1/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 S5/CrealityV1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10 S5/CrealityV2.2 - BLTouch/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 S5/CrealityV2.2 - BLTouch/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10 S5/CrealityV427 - BLTouch/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 S5/CrealityV427 - BLTouch/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10 V2/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 V2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10 V3/BigTreeTech SKR Mini E3 v3/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 V3/BigTreeTech SKR Mini E3 v3/Configuration_adv.h
@@ -1310,7 +1310,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10 V3/Stock/Configuration_adv.h
+++ b/config/examples/Creality/CR-10 V3/Stock/Configuration_adv.h
@@ -1310,7 +1310,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10/BigTreeTech SKR Mini E3 2.0/Configuration_adv.h
+++ b/config/examples/Creality/CR-10/BigTreeTech SKR Mini E3 2.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10/BigTreeTech SKR Mini E3 3.0/Configuration_adv.h
+++ b/config/examples/Creality/CR-10/BigTreeTech SKR Mini E3 3.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10/CrealityV1/Configuration_adv.h
+++ b/config/examples/Creality/CR-10/CrealityV1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10S Pro/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S Pro/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10S/BigTreeTech SKR 1.4 Turbo TMC2209/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/BigTreeTech SKR 1.4 Turbo TMC2209/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10S/BigTreeTech SKR 2.0 TMC2209/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/BigTreeTech SKR 2.0 TMC2209/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10S/BigTreeTech SKR Mini E3 2.0/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/BigTreeTech SKR Mini E3 2.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10S/BigTreeTech SKR Mini E3 3.0/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/BigTreeTech SKR Mini E3 3.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10S/BigTreeTech SKR Pro v1.2/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/BigTreeTech SKR Pro v1.2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10S/CrealityV1 - BLTouch/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/CrealityV1 - BLTouch/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-10S/CrealityV1/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/CrealityV1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-20 Pro/Configuration_adv.h
+++ b/config/examples/Creality/CR-20 Pro/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-20/RepRapWorld Minitronics20/Configuration_adv.h
+++ b/config/examples/Creality/CR-20/RepRapWorld Minitronics20/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-20/Stock/Configuration_adv.h
+++ b/config/examples/Creality/CR-20/Stock/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-30 PrintMill/Configuration_adv.h
+++ b/config/examples/Creality/CR-30 PrintMill/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-6 SE/Configuration_adv.h
+++ b/config/examples/Creality/CR-6 SE/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/config/examples/Creality/CR-8/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-2 Pro/CrealityV24S4/Configuration_adv.h
+++ b/config/examples/Creality/Ender-2 Pro/CrealityV24S4/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-2 Pro/CrealityV423/Configuration_adv.h
+++ b/config/examples/Creality/Ender-2 Pro/CrealityV423/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 Max Neo/BigTreeTech SKR Mini E3 3.0/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Max Neo/BigTreeTech SKR Mini E3 3.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 Max Neo/CrealityV422/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Max Neo/CrealityV422/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 Max/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Max/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 Neo/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Neo/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 Pro/BigTreeTech SKR 1.4 Turbo/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Pro/BigTreeTech SKR 1.4 Turbo/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 Pro/BigTreeTech SKR Mini E3 1.0/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Pro/BigTreeTech SKR Mini E3 1.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 Pro/BigTreeTech SKR Mini E3 1.2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Pro/BigTreeTech SKR Mini E3 1.2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 Pro/BigTreeTech SKR Mini E3 2.0/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Pro/BigTreeTech SKR Mini E3 2.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 Pro/BigTreeTech SKR Mini E3 3.0/BLTouch/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Pro/BigTreeTech SKR Mini E3 3.0/BLTouch/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 Pro/BigTreeTech SKR Mini E3 3.0/base/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Pro/BigTreeTech SKR Mini E3 3.0/base/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 Pro/Creality free-runs/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Pro/Creality free-runs/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 Pro/CrealityV1/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Pro/CrealityV1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 Pro/CrealityV422/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Pro/CrealityV422/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 Pro/CrealityV427/BLTouch/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Pro/CrealityV427/BLTouch/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 Pro/CrealityV427/base/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 Pro/CrealityV427/base/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 S1 Plus/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 S1 Plus/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 S1 Pro/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 S1 Pro/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 S1/STM32F1/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 S1/STM32F1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 S1/STM32F4/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 S1/STM32F4/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2 Neo/BigTreeTech SKR Mini E3 3.0/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2 Neo/BigTreeTech SKR Mini E3 3.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2 Neo/CrealityV422/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2 Neo/CrealityV422/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR E3 Turbo/CrealityUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR E3 Turbo/CrealityUI/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR E3 Turbo/MarlinUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR E3 Turbo/MarlinUI/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR E3 Turbo/ProUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR E3 Turbo/ProUI/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 2.0/CrealityUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 2.0/CrealityUI/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 2.0/MarlinUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 2.0/MarlinUI/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 2.0/ProUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 2.0/ProUI/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 3.0/CrealityUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 3.0/CrealityUI/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 3.0/MarlinUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 3.0/MarlinUI/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 3.0/ProUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/BigTreeTech SKR Mini E3 3.0/ProUI/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2/CrealityV422/CrealityUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/CrealityV422/CrealityUI/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2/CrealityV422/MarlinUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/CrealityV422/MarlinUI/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2/CrealityV422/ProUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/CrealityV422/ProUI/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2/CrealityV427/CrealityUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/CrealityV427/CrealityUI/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2/CrealityV427/MarlinUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/CrealityV427/MarlinUI/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3 V2/CrealityV427/ProUI/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3 V2/CrealityV427/ProUI/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/BigTreeTech E3 RRF/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/BigTreeTech E3 RRF/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/BigTreeTech Manta E3 EZ/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/BigTreeTech Manta E3 EZ/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/BigTreeTech SKR 1.4/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/BigTreeTech SKR 1.4/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/BigTreeTech SKR E3 Turbo/2-into-1 Hotend/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/BigTreeTech SKR E3 Turbo/2-into-1 Hotend/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/BigTreeTech SKR E3 Turbo/Dual Z/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/BigTreeTech SKR E3 Turbo/Dual Z/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/BigTreeTech SKR E3 Turbo/Single Extruder/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/BigTreeTech SKR E3 Turbo/Single Extruder/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/BigTreeTech SKR E3-DIP V1.1/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/BigTreeTech SKR E3-DIP V1.1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/BigTreeTech SKR Mini E3 1.0/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/BigTreeTech SKR Mini E3 1.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/BigTreeTech SKR Mini E3 1.2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/BigTreeTech SKR Mini E3 1.2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/BigTreeTech SKR Mini E3 2.0/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/BigTreeTech SKR Mini E3 2.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/BigTreeTech SKR Mini E3 3.0/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/BigTreeTech SKR Mini E3 3.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/Creality free-runs/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/Creality free-runs/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/CrealityV1/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/CrealityV1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/CrealityV422/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/CrealityV422/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/CrealityV427/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/CrealityV427/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/FYSETC Cheetah 1.2/BLTouch/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/FYSETC Cheetah 1.2/BLTouch/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/FYSETC Cheetah 1.2/base/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/FYSETC Cheetah 1.2/base/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/FYSETC Cheetah 2.0/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/FYSETC Cheetah 2.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/FYSETC Cheetah/BLTouch/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/FYSETC Cheetah/BLTouch/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/FYSETC Cheetah/base/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/FYSETC Cheetah/base/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/MEEB-3DP/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/MEEB-3DP/Configuration_adv.h
@@ -1307,7 +1307,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/MKS Robin E3/V1.0/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/MKS Robin E3/V1.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/MKS Robin E3/V1.1/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/MKS Robin E3/V1.1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/MKS Robin E3P/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/MKS Robin E3P/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-3/TH3D EZBoard Lite V2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/TH3D EZBoard Lite V2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5 Plus/BigTreeTech SKR 3/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 Plus/BigTreeTech SKR 3/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5 Plus/Creality 4.2.2 (RELOADED UI)/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 Plus/Creality 4.2.2 (RELOADED UI)/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5 Plus/CrealityV1 (ORIGIN UI)/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 Plus/CrealityV1 (ORIGIN UI)/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5 Plus/CrealityV1 (RELOADED UI)/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 Plus/CrealityV1 (RELOADED UI)/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5 Pro/BigTreeTech SKR E3 Turbo/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 Pro/BigTreeTech SKR E3 Turbo/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5 Pro/BigTreeTech SKR Mini E3 1.2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 Pro/BigTreeTech SKR Mini E3 1.2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5 Pro/BigTreeTech SKR Mini E3 2.0 with BLTouch/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 Pro/BigTreeTech SKR Mini E3 2.0 with BLTouch/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5 Pro/BigTreeTech SKR Mini E3 3.0 with BLTouch-HighTemp/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 Pro/BigTreeTech SKR Mini E3 3.0 with BLTouch-HighTemp/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5 Pro/CrealityV1/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 Pro/CrealityV1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5 Pro/CrealityV422/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 Pro/CrealityV422/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5 Pro/CrealityV427/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 Pro/CrealityV427/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5 S1/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5 S1/Configuration_adv.h
@@ -1311,7 +1311,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5/BigTreeTech SKR E3 Turbo with BLTouch/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/BigTreeTech SKR E3 Turbo with BLTouch/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5/BigTreeTech SKR E3 Turbo/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/BigTreeTech SKR E3 Turbo/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5/BigTreeTech SKR Mini E3 1.2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/BigTreeTech SKR Mini E3 1.2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5/BigTreeTech SKR Mini E3 2.0/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/BigTreeTech SKR Mini E3 2.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5/BigTreeTech SKR Mini E3 3.0 with BLTouch/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/BigTreeTech SKR Mini E3 3.0 with BLTouch/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5/Creality free-runs/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/Creality free-runs/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5/CrealityV1/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/CrealityV1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5/CrealityV427 with BLTouch/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/CrealityV427 with BLTouch/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-5/CrealityV427/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/CrealityV427/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Creality/Ender-6/Configuration_adv.h
+++ b/config/examples/Creality/Ender-6/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Daycom/3DP-100/Configuration_adv.h
+++ b/config/examples/Daycom/3DP-100/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/E3D/BigBox Dual/Configuration_adv.h
+++ b/config/examples/E3D/BigBox Dual/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/EXP3D/Imprimante multifonction/Configuration_adv.h
+++ b/config/examples/EXP3D/Imprimante multifonction/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/EasyThreeD/ET4000PLUS/Configuration_adv.h
+++ b/config/examples/EasyThreeD/ET4000PLUS/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Eazao/Zero/Configuration_adv.h
+++ b/config/examples/Eazao/Zero/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Einstart-S/Configuration_adv.h
+++ b/config/examples/Einstart-S/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Elegoo/Neptune 2/Configuration_adv.h
+++ b/config/examples/Elegoo/Neptune 2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Eryone/Thinker SE/Configuration_adv.h
+++ b/config/examples/Eryone/Thinker SE/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Eryone/Thinker V2/Configuration_adv.h
+++ b/config/examples/Eryone/Thinker V2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/FYSETC/AIO_II/Configuration_adv.h
+++ b/config/examples/FYSETC/AIO_II/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/FYSETC/F6_13/Configuration_adv.h
+++ b/config/examples/FYSETC/F6_13/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/FYSETC/S6/Configuration_adv.h
+++ b/config/examples/FYSETC/S6/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Felix/DUAL/Configuration_adv.h
+++ b/config/examples/Felix/DUAL/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Felix/Single/Configuration_adv.h
+++ b/config/examples/Felix/Single/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/FlashForge/Creator 2X/Configuration_adv.h
+++ b/config/examples/FlashForge/Creator 2X/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/FlashForge/CreatorPro/Configuration_adv.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration_adv.h
@@ -1310,7 +1310,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/FlyingBear/FlyingBearGhost_v3/Configuration_adv.h
+++ b/config/examples/FlyingBear/FlyingBearGhost_v3/Configuration_adv.h
@@ -1306,7 +1306,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/FlyingBear/P902/Configuration_adv.h
+++ b/config/examples/FlyingBear/P902/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/FlyingBear/P905H/Configuration_adv.h
+++ b/config/examples/FlyingBear/P905H/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/FoamCutter/generic/Configuration_adv.h
+++ b/config/examples/FoamCutter/generic/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/FoamCutter/rcKeith/Configuration_adv.h
+++ b/config/examples/FoamCutter/rcKeith/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/FolgerTech/FT-5 R2/Configuration_adv.h
+++ b/config/examples/FolgerTech/FT-5 R2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Formbot/Raptor/Configuration_adv.h
+++ b/config/examples/Formbot/Raptor/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/A10/Configuration_adv.h
+++ b/config/examples/Geeetech/A10/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/A10D/Configuration_adv.h
+++ b/config/examples/Geeetech/A10D/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/A10M/Stock LCD/Configuration_adv.h
+++ b/config/examples/Geeetech/A10M/Stock LCD/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/A10M/YHCB2004_V4.1/Configuration_adv.h
+++ b/config/examples/Geeetech/A10M/YHCB2004_V4.1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/A10PRO/Configuration_adv.h
+++ b/config/examples/Geeetech/A10PRO/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/A10T/Stock LCD/Configuration_adv.h
+++ b/config/examples/Geeetech/A10T/Stock LCD/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/A10T/YHCB2004_V4.1/Configuration_adv.h
+++ b/config/examples/Geeetech/A10T/YHCB2004_V4.1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/A20/Configuration_adv.h
+++ b/config/examples/Geeetech/A20/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/A20M/Configuration_adv.h
+++ b/config/examples/Geeetech/A20M/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/A20T/Configuration_adv.h
+++ b/config/examples/Geeetech/A20T/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/A30/Configuration_adv.h
+++ b/config/examples/Geeetech/A30/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/A30M/Configuration_adv.h
+++ b/config/examples/Geeetech/A30M/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/A30T/Configuration_adv.h
+++ b/config/examples/Geeetech/A30T/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/D200/Configuration_adv.h
+++ b/config/examples/Geeetech/D200/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/Duplicator5/Configuration_adv.h
+++ b/config/examples/Geeetech/Duplicator5/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/E180/Configuration_adv.h
+++ b/config/examples/Geeetech/E180/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/GT2560/Configuration_adv.h
+++ b/config/examples/Geeetech/GT2560/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration_adv.h
+++ b/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/M201/Configuration_adv.h
+++ b/config/examples/Geeetech/M201/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/MeCreator2/Configuration_adv.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/Me_creator/Configuration_adv.h
+++ b/config/examples/Geeetech/Me_creator/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/Me_ducer/Configuration_adv.h
+++ b/config/examples/Geeetech/Me_ducer/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/PI3A PRO/Configuration_adv.h
+++ b/config/examples/Geeetech/PI3A PRO/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/HMS434/Configuration_adv.h
+++ b/config/examples/HMS434/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Hictop/3DP-17/Configuration_adv.h
+++ b/config/examples/Hictop/3DP-17/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Intamsys/FunmatHT 4988/Configuration_adv.h
+++ b/config/examples/Intamsys/FunmatHT 4988/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/JGAurora/A1/Configuration_adv.h
+++ b/config/examples/JGAurora/A1/Configuration_adv.h
@@ -1314,7 +1314,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/JGAurora/A3/Configuration_adv.h
+++ b/config/examples/JGAurora/A3/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/config/examples/JGAurora/A5/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/JGAurora/A5S/Configuration_adv.h
+++ b/config/examples/JGAurora/A5S/Configuration_adv.h
@@ -1314,7 +1314,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/JGAurora/Magic/Configuration_adv.h
+++ b/config/examples/JGAurora/Magic/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Kingroon/KP3/Configuration_adv.h
+++ b/config/examples/Kingroon/KP3/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Kingroon/KP3S/Configuration_adv.h
+++ b/config/examples/Kingroon/KP3S/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Kingroon/KP3S_Pro/Configuration_adv.h
+++ b/config/examples/Kingroon/KP3S_Pro/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Kingroon/KP5L-DIY/Configuration_adv.h
+++ b/config/examples/Kingroon/KP5L-DIY/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Labists/ET4/Configuration_adv.h
+++ b/config/examples/Labists/ET4/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Longer/LK5/Configuration_adv.h
+++ b/config/examples/Longer/LK5/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/LulzBot/TAZ4/Configuration_adv.h
+++ b/config/examples/LulzBot/TAZ4/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/MBot/Cube/Configuration_adv.h
+++ b/config/examples/MBot/Cube/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/MZ3D/360/Configuration_adv.h
+++ b/config/examples/MZ3D/360/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/MakerBot/Replicator Dual/Configuration_adv.h
+++ b/config/examples/MakerBot/Replicator Dual/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/MakerBot/Replicator Single/Configuration_adv.h
+++ b/config/examples/MakerBot/Replicator Single/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/MakerFarm/Pegasus 12/Configuration_adv.h
+++ b/config/examples/MakerFarm/Pegasus 12/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/MakerGear/M2 Rev H/Configuration_adv.h
+++ b/config/examples/MakerGear/M2 Rev H/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/MakerParts/Configuration_adv.h
+++ b/config/examples/MakerParts/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/MakerTech3D/Proforge2sDual/Configuration_adv.h
+++ b/config/examples/MakerTech3D/Proforge2sDual/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Malyan/M150/Configuration_adv.h
+++ b/config/examples/Malyan/M150/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Malyan/M180/Configuration_adv.h
+++ b/config/examples/Malyan/M180/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Malyan/M200/Configuration_adv.h
+++ b/config/examples/Malyan/M200/Configuration_adv.h
@@ -1310,7 +1310,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Materia101/Configuration_adv.h
+++ b/config/examples/Materia101/Configuration_adv.h
@@ -1306,7 +1306,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Micromake/C1/basic/Configuration_adv.h
+++ b/config/examples/Micromake/C1/basic/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Mks/Robin/Configuration_adv.h
+++ b/config/examples/Mks/Robin/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Mks/Robin_Lite3/Configuration_adv.h
+++ b/config/examples/Mks/Robin_Lite3/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Mks/Robin_Pro/Configuration_adv.h
+++ b/config/examples/Mks/Robin_Pro/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/config/examples/Mks/Sbase/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Modix/Big60/Configuration_adv.h
+++ b/config/examples/Modix/Big60/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Nextion/Configuration_adv.h
+++ b/config/examples/Nextion/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/ORD Bot/Hadron/Sanguinololu/Configuration_adv.h
+++ b/config/examples/ORD Bot/Hadron/Sanguinololu/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Opulo/Lumen_REV3/Configuration_adv.h
+++ b/config/examples/Opulo/Lumen_REV3/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Opulo/Lumen_REV4/Configuration_adv.h
+++ b/config/examples/Opulo/Lumen_REV4/Configuration_adv.h
@@ -1307,7 +1307,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Opulo/Lumen_REV5/Configuration_adv.h
+++ b/config/examples/Opulo/Lumen_REV5/Configuration_adv.h
@@ -1307,7 +1307,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Ortur 4/Configuration_adv.h
+++ b/config/examples/Ortur 4/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Polargraph/Configuration_adv.h
+++ b/config/examples/Polargraph/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Printrbot/PrintrboardG2/Configuration_adv.h
+++ b/config/examples/Printrbot/PrintrboardG2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Printrbot/Simple Metal RevD/Configuration_adv.h
+++ b/config/examples/Printrbot/Simple Metal RevD/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Printrbot/Simple_Metal_RevF6/Configuration_adv.h
+++ b/config/examples/Printrbot/Simple_Metal_RevF6/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Prusa/MK3/Configuration_adv.h
+++ b/config/examples/Prusa/MK3/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Prusa/MK3S-BigTreeTech-BTT002/Configuration_adv.h
+++ b/config/examples/Prusa/MK3S-BigTreeTech-BTT002/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Qidi/Qidi 1/Configuration_adv.h
+++ b/config/examples/Qidi/Qidi 1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Raiscube/A8r/Configuration_adv.h
+++ b/config/examples/Raiscube/A8r/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/RapideLite/RL200/Configuration_adv.h
+++ b/config/examples/RapideLite/RL200/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Renkforce/RF100/Configuration_adv.h
+++ b/config/examples/Renkforce/RF100/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Renkforce/RF100XL/Configuration_adv.h
+++ b/config/examples/Renkforce/RF100XL/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Renkforce/RF100v2/Configuration_adv.h
+++ b/config/examples/Renkforce/RF100v2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/RepRapPro/Huxley/Configuration_adv.h
+++ b/config/examples/RepRapPro/Huxley/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/RepRapWorld/Megatronics/Configuration_adv.h
+++ b/config/examples/RepRapWorld/Megatronics/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/RepRapWorld/Minitronics11/Configuration_adv.h
+++ b/config/examples/RepRapWorld/Minitronics11/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/RepRapWorld/Minitronics20/CNC/Configuration_adv.h
+++ b/config/examples/RepRapWorld/Minitronics20/CNC/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/RigidBot/Configuration_adv.h
+++ b/config/examples/RigidBot/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Robo3D/R1+/Configuration_adv.h
+++ b/config/examples/Robo3D/R1+/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Rolohaun/Rook MK1/Configuration_adv.h
+++ b/config/examples/Rolohaun/Rook MK1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/SCARA/MP_SCARA/Configuration_adv.h
+++ b/config/examples/SCARA/MP_SCARA/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/SCARA/Morgan/Configuration_adv.h
+++ b/config/examples/SCARA/Morgan/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/STM32/STM32F103RE/Configuration_adv.h
+++ b/config/examples/STM32/STM32F103RE/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Simax/Mi-M200/Configuration_adv.h
+++ b/config/examples/Simax/Mi-M200/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Simulator/Configuration_adv.h
+++ b/config/examples/Simulator/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Sovol/SV-01/BigTreeTech SKR E3 Turbo/Configuration_adv.h
+++ b/config/examples/Sovol/SV-01/BigTreeTech SKR E3 Turbo/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Sovol/SV-01/BigTreeTech SKR Mini E3 2.0/Configuration_adv.h
+++ b/config/examples/Sovol/SV-01/BigTreeTech SKR Mini E3 2.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Sovol/SV-01/BigTreeTech SKR Mini E3 3.0/Configuration_adv.h
+++ b/config/examples/Sovol/SV-01/BigTreeTech SKR Mini E3 3.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Sovol/SV-01/CrealityV22/Configuration_adv.h
+++ b/config/examples/Sovol/SV-01/CrealityV22/Configuration_adv.h
@@ -1310,7 +1310,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Sovol/SV-01/CrealityV221/Configuration_adv.h
+++ b/config/examples/Sovol/SV-01/CrealityV221/Configuration_adv.h
@@ -1310,7 +1310,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Sovol/SV-02/Configuration_adv.h
+++ b/config/examples/Sovol/SV-02/Configuration_adv.h
@@ -1310,7 +1310,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Sovol/SV-03/Configuration_adv.h
+++ b/config/examples/Sovol/SV-03/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Sovol/SV-05/Configuration_adv.h
+++ b/config/examples/Sovol/SV-05/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Sovol/SV-06 Plus/Configuration_adv.h
+++ b/config/examples/Sovol/SV-06 Plus/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Sovol/SV-06/Configuration_adv.h
+++ b/config/examples/Sovol/SV-06/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Sunlu/S8/Configuration_adv.h
+++ b/config/examples/Sunlu/S8/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Sunlu/T3/Configuration_adv.h
+++ b/config/examples/Sunlu/T3/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/TPARA/AXEL_TPARA/Configuration_adv.h
+++ b/config/examples/TPARA/AXEL_TPARA/Configuration_adv.h
@@ -1310,7 +1310,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tevo/Michelangelo/Configuration_adv.h
+++ b/config/examples/Tevo/Michelangelo/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tevo/Nereus/Configuration_adv.h
+++ b/config/examples/Tevo/Nereus/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tevo/Tarantula Pro/MKS Gen_L/Configuration_adv.h
+++ b/config/examples/Tevo/Tarantula Pro/MKS Gen_L/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tevo/Tarantula Pro/MKS SGen_L/Configuration_adv.h
+++ b/config/examples/Tevo/Tarantula Pro/MKS SGen_L/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tevo/Tornado/V2 (MKS Gen_L)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V2 (MKS Gen_L)/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tinkerine/Ditto Pro/RAMPS 1.4/Configuration_adv.h
+++ b/config/examples/Tinkerine/Ditto Pro/RAMPS 1.4/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/TinyBoy2/Configuration_adv.h
+++ b/config/examples/TinyBoy2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tronxy/D01/CXY-v6-191017 board/Configuration_adv.h
+++ b/config/examples/Tronxy/D01/CXY-v6-191017 board/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tronxy/X1/Configuration_adv.h
+++ b/config/examples/Tronxy/X1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tronxy/X3A/Configuration_adv.h
+++ b/config/examples/Tronxy/X3A/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tronxy/X5S-2E/Green Board (Chitu V5)/Configuration_adv.h
+++ b/config/examples/Tronxy/X5S-2E/Green Board (Chitu V5)/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tronxy/X5S-2E/Red Board (Tronxy 3.1.0)/Configuration_adv.h
+++ b/config/examples/Tronxy/X5S-2E/Red Board (Tronxy 3.1.0)/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tronxy/X5S/Configuration_adv.h
+++ b/config/examples/Tronxy/X5S/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tronxy/X5SA Pro/Configuration_adv.h
+++ b/config/examples/Tronxy/X5SA Pro/Configuration_adv.h
@@ -1322,7 +1322,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tronxy/X5SA-2E/Configuration_adv.h
+++ b/config/examples/Tronxy/X5SA-2E/Configuration_adv.h
@@ -1313,7 +1313,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tronxy/X5SA/Configuration_adv.h
+++ b/config/examples/Tronxy/X5SA/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tronxy/XY100/Configuration_adv.h
+++ b/config/examples/Tronxy/XY100/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Tronxy/XY2-Pro/Configuration_adv.h
+++ b/config/examples/Tronxy/XY2-Pro/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Turnigy/Fabrikator/Configuration_adv.h
+++ b/config/examples/Turnigy/Fabrikator/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Two Trees/BlueR Plus/Configuration_adv.h
+++ b/config/examples/Two Trees/BlueR Plus/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Two Trees/BlueR/BlueR V1/Configuration_adv.h
+++ b/config/examples/Two Trees/BlueR/BlueR V1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Two Trees/BlueR/BlueR V2/Configuration_adv.h
+++ b/config/examples/Two Trees/BlueR/BlueR V2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Two Trees/BlueR/BlueR V3/Configuration_adv.h
+++ b/config/examples/Two Trees/BlueR/BlueR V3/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Two Trees/SP-5_V3/Configuration_adv.h
+++ b/config/examples/Two Trees/SP-5_V3/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Two Trees/Sapphire Plus/Sapphire Plus V2.1/Configuration_adv.h
+++ b/config/examples/Two Trees/Sapphire Plus/Sapphire Plus V2.1/Configuration_adv.h
@@ -1314,7 +1314,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Two Trees/Sapphire Plus/Sapphire Plus V2/Configuration_adv.h
+++ b/config/examples/Two Trees/Sapphire Plus/Sapphire Plus V2/Configuration_adv.h
@@ -1314,7 +1314,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Two Trees/Sapphire Pro/Configuration_adv.h
+++ b/config/examples/Two Trees/Sapphire Pro/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/UltiMachine/Archim1/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Ultimaker/Ultimaker 2+/Configuration_adv.h
+++ b/config/examples/Ultimaker/Ultimaker 2+/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Ultimaker/Ultimaker 2/Configuration_adv.h
+++ b/config/examples/Ultimaker/Ultimaker 2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Ultimaker/Ultimaker Original (1.5.7)/Configuration_adv.h
+++ b/config/examples/Ultimaker/Ultimaker Original (1.5.7)/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Ultimaker/Ultimaker Original Plus (2.1.1)/Configuration_adv.h
+++ b/config/examples/Ultimaker/Ultimaker Original Plus (2.1.1)/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Ultimaker/Ultimaker Original Plus DXU/Configuration_adv.h
+++ b/config/examples/Ultimaker/Ultimaker Original Plus DXU/Configuration_adv.h
@@ -1306,7 +1306,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/VORONDesign/Configuration_adv.h
+++ b/config/examples/VORONDesign/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Velleman/K8200 Upgraded/Configuration_adv.h
+++ b/config/examples/Velleman/K8200 Upgraded/Configuration_adv.h
@@ -1321,7 +1321,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/config/examples/Velleman/K8200/Configuration_adv.h
@@ -1321,7 +1321,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Velleman/K8400/Dual-head/Configuration_adv.h
+++ b/config/examples/Velleman/K8400/Dual-head/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Velleman/K8400/Single-head/Configuration_adv.h
+++ b/config/examples/Velleman/K8400/Single-head/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Voxelab/Aquila/BigTreeTech SKR Mini E3 2.0/Configuration_adv.h
+++ b/config/examples/Voxelab/Aquila/BigTreeTech SKR Mini E3 2.0/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/WASP/PowerWASP/Configuration_adv.h
+++ b/config/examples/WASP/PowerWASP/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator 4S/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 4S/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator 9/MK1/300/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 9/MK1/300/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator 9/MK1/400/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 9/MK1/400/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator 9/MK1/500/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 9/MK1/500/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator 9/MK1u2/300/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 9/MK1u2/300/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator 9/MK1u2/400/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 9/MK1u2/400/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator 9/MK1u2/500/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 9/MK1u2/500/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator 9/MK2/300/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 9/MK2/300/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator 9/MK2/400/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 9/MK2/400/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator 9/MK2/500/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 9/MK2/500/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator 9/MK3/300/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 9/MK3/300/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator 9/MK3/400/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 9/MK3/400/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator 9/MK3/500/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 9/MK3/500/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator i3 2.1/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator i3 2.1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Wanhao/Duplicator i3 Plus/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator i3 Plus/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Weedo/Tina2/V2/Configuration_adv.h
+++ b/config/examples/Weedo/Tina2/V2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Weedo/Tina2/V3/Configuration_adv.h
+++ b/config/examples/Weedo/Tina2/V3/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Weistek/wt150/Configuration_adv.h
+++ b/config/examples/Weistek/wt150/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Zonestar/P802M/Configuration_adv.h
+++ b/config/examples/Zonestar/P802M/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Zonestar/P802QR2/BigTreeTech SKR 1.4 Turbo (A4988)/Configuration_adv.h
+++ b/config/examples/Zonestar/P802QR2/BigTreeTech SKR 1.4 Turbo (A4988)/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/Zonestar/P802QR2/BigTreeTech SKR 1.4 Turbo (TMC2209)/Configuration_adv.h
+++ b/config/examples/Zonestar/P802QR2/BigTreeTech SKR 1.4 Turbo (TMC2209)/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/Anycubic/Kossel Linear Plus/Configuration_adv.h
+++ b/config/examples/delta/Anycubic/Kossel Linear Plus/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/Anycubic/Predator/Configuration_adv.h
+++ b/config/examples/delta/Anycubic/Predator/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/Dreammaker/Overlord/Configuration_adv.h
+++ b/config/examples/delta/Dreammaker/Overlord/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/Dreammaker/Overlord_Pro/Configuration_adv.h
+++ b/config/examples/delta/Dreammaker/Overlord_Pro/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/FLSUN/Q5-nano_v1/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/Q5-nano_v1/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/FLSUN/Q5-nano_v2/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/Q5-nano_v2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/FLSUN/QQ-S/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/QQ-S/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/FLSUN/QQS-Pro/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/QQS-Pro/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/Geeetech/G2/Configuration_adv.h
+++ b/config/examples/delta/Geeetech/G2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/Geeetech/G2Pro/Configuration_adv.h
+++ b/config/examples/delta/Geeetech/G2Pro/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/Geeetech/G2S/Configuration_adv.h
+++ b/config/examples/delta/Geeetech/G2S/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/Geeetech/G2SPro/Configuration_adv.h
+++ b/config/examples/delta/Geeetech/G2SPro/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/Hatchbox_Alpha/Configuration_adv.h
+++ b/config/examples/delta/Hatchbox_Alpha/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/MKS/SBASE/Configuration_adv.h
+++ b/config/examples/delta/MKS/SBASE/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/Malyan M300/Configuration_adv.h
+++ b/config/examples/delta/Malyan M300/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/Micromake-D1/MKS-Gen-L-V2.1/Configuration_adv.h
+++ b/config/examples/delta/Micromake-D1/MKS-Gen-L-V2.1/Configuration_adv.h
@@ -1310,7 +1310,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/Micromake-D1/RAMPS-1.4/Configuration_adv.h
+++ b/config/examples/delta/Micromake-D1/RAMPS-1.4/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/Tevo Little Monster/Configuration_adv.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/Velleman/K8800/Configuration_adv.h
+++ b/config/examples/delta/Velleman/K8800/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/generic/Configuration_adv.h
+++ b/config/examples/delta/generic/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/kossel_clear/Configuration_adv.h
+++ b/config/examples/delta/kossel_clear/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/kossel_pro/Configuration_adv.h
+++ b/config/examples/delta/kossel_pro/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/linear_axes/Octopus 8 LINEAR_AXES/Configuration_adv.h
+++ b/config/examples/linear_axes/Octopus 8 LINEAR_AXES/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/linear_axes/RAMPS 5 LINEAR_AXES/Configuration_adv.h
+++ b/config/examples/linear_axes/RAMPS 5 LINEAR_AXES/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/makibox/Configuration_adv.h
+++ b/config/examples/makibox/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion

--- a/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -1308,7 +1308,7 @@
 #endif
 
 #if ANY(INPUT_SHAPING_X, INPUT_SHAPING_Y, INPUT_SHAPING_Z, FTM_SHAPER_ZV, FTM_SHAPER_ZVD, FTM_SHAPER_ZVDD, FTM_SHAPER_ZVDDD, FTM_SHAPER_EI, FTM_SHAPER_2HEI, FTM_SHAPER_3HEI, FTM_SHAPER_MZV)
-  //#define RESONANCE_TEST              // Sine sweep motion for resonance study
+  //#define FTM_RESONANCE_TEST              // Sine sweep motion for resonance study
 #endif
 
 // @section motion


### PR DESCRIPTION
### Description

Global rename was missed in the Configurations repo when FTM_RESONANCE_TEST 
was introduced in the main Marlin repo. All 411 occurrences were bare 
RESONANCE_TEST with no existing FTM_RESONANCE_TEST references present.

Replaced via:
grep -rlZ 'RESONANCE_TEST' . | xargs -0 sed -i 's/\bRESONANCE_TEST\b/FTM_RESONANCE_TEST/g'

Tested: zero remaining bare RESONANCE_TEST occurrences confirmed by grep.
Affects: config/default and all config/examples across all printer variants.

### Benefits

Enables FTM_RESONANCE_TEST to compile correctly when uncommented in any 
example config. Previously the bare RESONANCE_TEST define was silently 
ignored by the preprocessor, causing the feature to appear configured 
but never actually compile in.

### Related Issues

None — discovered while testing FTM_RESONANCE_TEST on Ender 3 V2 with 
Creality 4.2.2 board.
