### PR TITLE
[Ender 5 Plus] Fix build error in sanity checks

### DIFF
--- a/config/examples/Creality/Ender-5 Plus/BigTreeTech SKR 3/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/BigTreeTech SKR 3/Configuration.h
@@ -1373,7 +1373,7 @@
  * Override with M203
  *                                      X, Y, Z [, I [, J [, K...]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_FEEDRATE          { 6250, 6250, 15, 15000 }
+#define DEFAULT_MAX_FEEDRATE          { 6250, 6250, 15, 5000 }
 
 //#define LIMITED_MAX_FR_EDITING        // Limit edit via M203 or LCD to DEFAULT_MAX_FEEDRATE * 2
 #if ENABLED(LIMITED_MAX_FR_EDITING)

--- a/config/examples/Creality/Ender-5 Plus/Creality 4.2.2 (RELOADED UI)/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/Creality 4.2.2 (RELOADED UI)/Configuration.h
@@ -1379,7 +1379,7 @@
  * Override with M203
  *                                      X, Y, Z [, I [, J [, K...]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_FEEDRATE          { 6250, 6250, 15, 15000 }
+#define DEFAULT_MAX_FEEDRATE          { 6250, 6250, 15, 5000 }
 
 //#define LIMITED_MAX_FR_EDITING        // Limit edit via M203 or LCD to DEFAULT_MAX_FEEDRATE * 2
 #if ENABLED(LIMITED_MAX_FR_EDITING)

--- a/config/examples/Creality/Ender-5 Plus/CrealityV1 (ORIGIN UI)/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/CrealityV1 (ORIGIN UI)/Configuration.h
@@ -1382,7 +1382,7 @@
  * Override with M203
  *                                      X, Y, Z [, I [, J [, K...]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_FEEDRATE          { 6250, 6250, 15, 15000 }
+#define DEFAULT_MAX_FEEDRATE          { 6250, 6250, 15, 5000 }
 
 //#define LIMITED_MAX_FR_EDITING        // Limit edit via M203 or LCD to DEFAULT_MAX_FEEDRATE * 2
 #if ENABLED(LIMITED_MAX_FR_EDITING)

--- a/config/examples/Creality/Ender-5 Plus/CrealityV1 (RELOADED UI)/Configuration.h
+++ b/config/examples/Creality/Ender-5 Plus/CrealityV1 (RELOADED UI)/Configuration.h
@@ -1382,7 +1382,7 @@
  * Override with M203
  *                                      X, Y, Z [, I [, J [, K...]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_FEEDRATE          { 6250, 6250, 15, 15000 }
+#define DEFAULT_MAX_FEEDRATE          { 6250, 6250, 15, 5000 }
 
 //#define LIMITED_MAX_FR_EDITING        // Limit edit via M203 or LCD to DEFAULT_MAX_FEEDRATE * 2
 #if ENABLED(LIMITED_MAX_FR_EDITING)


### PR DESCRIPTION
Slow down! DEFAULT_MAX_FEEDRATE[E] * DEFAULT_AXIS_STEPS_PER_UNIT[E] > MAXIMUM_STEPPER_RATE (500000).

DEFAULT_MAX_FEEDRATE = 15000, DEFAULT_AXIS_STEPS_PER_UNIT = 93.02 = 1395300

Change DEFAULT_MAX_FEEDRATE to 5000 to make the sanity check value 465100 - which is less than MAXIMUM_STEPPER_RATE (500000).