### PR TITLE
Upgraded config for FlyingBear P905H

### DIFF
--- a/config/examples/FlyingBear/P905H/Configuration.h
+++ b/config/examples/FlyingBear/P905H/Configuration.h
@@ -727,7 +727,7 @@
   //#define PID_PARAMS_PER_HOTEND // Use separate PID parameters for each extruder (useful for mismatched extruders)
                                   // Set/get with G-code: M301 E[extruder number, 0-2]
 
-  // P905
+  // P905H
   #if ENABLED(PID_PARAMS_PER_HOTEND)
     // Specify up to one value per hotend here, according to your setup.
     // If there are fewer values, the last one applies to the remaining hotends.
@@ -3393,7 +3393,7 @@
 #endif
 
 //
-// Touch-screen LCD for Malyan M200 printers
+// LCD for Malyan M200/M300 printers
 //
 //#define MALYAN_LCD
 

--- a/config/examples/FlyingBear/P905H/Configuration.h
+++ b/config/examples/FlyingBear/P905H/Configuration.h
@@ -70,7 +70,7 @@
 
 // Choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_MKS_GEN_13
+  #define MOTHERBOARD BOARD_MKS_GEN_L
 #endif
 
 // @section serial
@@ -1362,7 +1362,7 @@
  * Override with M92 (when enabled below)
  *                                      X, Y, Z [, I [, J [, K...]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 100, 100, 800, 94 }
+#define DEFAULT_AXIS_STEPS_PER_UNIT   { 100, 100, 800, 96 }
 
 /**
  * Enable support for M92. Disable to save at least ~530 bytes of flash.
@@ -1374,7 +1374,7 @@
  * Override with M203
  *                                      X, Y, Z [, I [, J [, K...]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_FEEDRATE          { 150, 150, 4, 25 }
+#define DEFAULT_MAX_FEEDRATE          { 150, 150, 5, 25 }
 
 //#define LIMITED_MAX_FR_EDITING        // Limit edit via M203 or LCD to DEFAULT_MAX_FEEDRATE * 2
 #if ENABLED(LIMITED_MAX_FR_EDITING)
@@ -1402,9 +1402,9 @@
  *   M204 R    Retract Acceleration
  *   M204 T    Travel Acceleration
  */
-#define DEFAULT_ACCELERATION           400    // X, Y, Z and E acceleration for printing moves
-#define DEFAULT_RETRACT_ACCELERATION  3000    // E acceleration for retracts
-#define DEFAULT_TRAVEL_ACCELERATION    600    // X, Y, Z acceleration for travel (non printing) moves
+#define DEFAULT_ACCELERATION           800    // X, Y, Z and E acceleration for printing moves
+#define DEFAULT_RETRACT_ACCELERATION   3000   // E acceleration for retracts
+#define DEFAULT_TRAVEL_ACCELERATION    1000   // X, Y, Z acceleration for travel (non printing) moves
 
 /**
  * Default Jerk limits (mm/s)
@@ -1414,13 +1414,13 @@
  * When changing speed and direction, if the difference is less than the
  * value set here, it may happen instantaneously.
  */
-// P905H could work with classic jerk too
-//#define CLASSIC_JERK
+// P905H should work with classic jerk
+#define CLASSIC_JERK
 #if ENABLED(CLASSIC_JERK)
   #define DEFAULT_XJERK 10.0
-  #define DEFAULT_YJERK 10.0
+  #define DEFAULT_YJERK  8.0
   #define DEFAULT_ZJERK  0.3
-  #define DEFAULT_EJERK  2.5
+  #define DEFAULT_EJERK 10.0
   //#define DEFAULT_IJERK  0.3
   //#define DEFAULT_JJERK  0.3
   //#define DEFAULT_KJERK  0.3
@@ -1748,7 +1748,7 @@
 
 // Most probes should stay away from the edges of the bed, but
 // with NOZZLE_AS_PROBE this can be negative for a wider probing area.
-#define PROBING_MARGIN 20
+#define PROBING_MARGIN 35
 
 // X and Y axis travel speed between probes.
 // Leave undefined to use the average of the current XY homing feedrate.
@@ -1866,10 +1866,10 @@
 //#define DELAY_BEFORE_PROBING 200  // (ms) To prevent vibrations from triggering piezo sensors
 
 // Require minimum nozzle and/or bed temperature for probing
-//#define PREHEAT_BEFORE_PROBING
+#define PREHEAT_BEFORE_PROBING
 #if ENABLED(PREHEAT_BEFORE_PROBING)
-  #define PROBING_NOZZLE_TEMP 120   // (°C) Only applies to E0 at this time
-  #define PROBING_BED_TEMP     50
+  #define PROBING_NOZZLE_TEMP 100   // (°C) Only applies to E0 at this time
+  #define PROBING_BED_TEMP     60
 #endif
 
 // @section stepper drivers
@@ -2585,7 +2585,7 @@
 #define PREHEAT_1_FAN_SPEED     0 // Value from 0 to 255
 
 #define PREHEAT_2_LABEL       "ABS"
-#define PREHEAT_2_TEMP_HOTEND 230
+#define PREHEAT_2_TEMP_HOTEND 200
 #define PREHEAT_2_TEMP_BED    100
 #define PREHEAT_2_TEMP_CHAMBER 35
 #define PREHEAT_2_FAN_SPEED     0 // Value from 0 to 255

--- a/config/examples/FlyingBear/P905H/Configuration_adv.h
+++ b/config/examples/FlyingBear/P905H/Configuration_adv.h
@@ -1583,7 +1583,7 @@
 //#define DISABLE_REDUCED_ACCURACY_WARNING
 
 #if HAS_MANUAL_MOVE_MENU
-  #define MANUAL_FEEDRATE { 50*60, 50*60, 4*60, 2*60 } // (mm/min) Feedrates for manual moves along X, Y, Z, E from panel
+  #define MANUAL_FEEDRATE { 50*60, 50*60, 4*60, 4*60 } // (mm/min) Feedrates for manual moves along X, Y, Z, E from panel
   #define FINE_MANUAL_MOVE 0.025    // (mm) Smallest manual move (< 0.1mm) applying to Z on most machines
   #if IS_ULTIPANEL
     #define MANUAL_E_MOVES_RELATIVE // Display extruder move distance rather than "position"
@@ -2476,13 +2476,16 @@
  *
  * See https://marlinfw.org/docs/features/lin_advance.html for full instructions.
  */
-//#define LIN_ADVANCE
+
+ #define LIN_ADVANCE
 
 #if ANY(LIN_ADVANCE, FT_MOTION)
   #if ENABLED(DISTINCT_E_FACTORS)
     #define ADVANCE_K { 0.22 }    // (mm) Compression length per 1mm/s extruder speed, per extruder. Override with 'M900 T<tool> K<mm>'.
   #else
-    #define ADVANCE_K 0.22        // (mm) Compression length for all extruders. Override with 'M900 K<mm>'.
+    // For P905H 0.4 is a bare minimum but optimal values are in the range 0.8-1.0
+    // NOTE: With non zero value it lags on a speed > 90mm/s
+    #define ADVANCE_K 0.4        // (mm) Compression length for all extruders. Override with 'M900 K<mm>'.
   #endif
   //#define ADVANCE_K_EXTRA       // Add a second linear advance constant, configurable with 'M900 L'.
 #endif

--- a/config/examples/FlyingBear/P905H/Configuration_adv.h
+++ b/config/examples/FlyingBear/P905H/Configuration_adv.h
@@ -1852,8 +1852,8 @@
 
   #define SD_PROCEDURE_DEPTH 1              // Increase if you need more nested M32 calls
 
-  #define SD_FINISHED_STEPPERRELEASE true          // Disable steppers when SD Print is finished
-  #define SD_FINISHED_RELEASECOMMAND "M84 X Y Z E" // You might want to keep the Z enabled so your bed stays in place.
+  #define SD_FINISHED_STEPPERRELEASE true   // Disable steppers when SD Print is finished
+  #define SD_FINISHED_RELEASECOMMAND "M84"  // Use "M84XYE" to keep Z enabled so your bed stays in place
 
   // Reverse SD sort to show "more recent" files first, according to the card's FAT.
   // Since the FAT gets out of order with usage, SDCARD_SORT_ALPHA is recommended.
@@ -1890,9 +1890,6 @@
    * during SD printing. If the recovery file is found at boot time, present
    * an option on the LCD screen to continue the print from the last-known
    * point in the file.
-   *
-   * If the machine reboots when resuming a print you may need to replace or
-   * reformat the SD card. (Bad sectors delay startup triggering the watchdog.)
    */
   //#define POWER_LOSS_RECOVERY
   #if ENABLED(POWER_LOSS_RECOVERY)
@@ -2480,8 +2477,7 @@
  *
  * See https://marlinfw.org/docs/features/lin_advance.html for full instructions.
  */
-
- #define LIN_ADVANCE
+#define LIN_ADVANCE
 
 #if ANY(LIN_ADVANCE, FT_MOTION)
   #if ENABLED(DISTINCT_E_FACTORS)
@@ -2489,7 +2485,7 @@
   #else
     // For P905H 0.4 is a bare minimum but optimal values are in the range 0.8-1.0
     // NOTE: With non zero value it lags on a speed > 90mm/s
-    #define ADVANCE_K 0.4        // (mm) Compression length for all extruders. Override with 'M900 K<mm>'.
+    #define ADVANCE_K 0.4         // (mm) Compression length for all extruders. Override with 'M900 K<mm>'.
   #endif
   //#define ADVANCE_K_EXTRA       // Add a second linear advance constant, configurable with 'M900 L'.
 #endif

--- a/config/examples/FlyingBear/P905H/README.md
+++ b/config/examples/FlyingBear/P905H/README.md
@@ -1,14 +1,11 @@
-# Flying Bear P905H configuration
+# Flying Bear P905H
 
-This configuration is for a P905H with **a single extruder and inductive Z-sensor**. It's been thoroughly tested, and I've tried to make the printer work smoothly, so this configuration is more focused on print quality than speed.
+Configuration is based on P905H with **a single extruder and inductive Z-sensor**.
 
-- Use this firmware as a baseline for other P905 modifications.
-- Find other notes in the config files by searching for "P905H".
+I've tried to adapt original Marlin 1.x limits to Marlin 2.1.x with classical jerk and linear advance enabled.
 
-## Build Instructions
-  - Get Visual Studio Code and install the "Auto Build Marlin" extension.
-  - Download the [Marlin source code](//marlinfw.org/meta/download/).
-  - Copy the two Configuration files from this folder into the 'Marlin' folder (replacing the existing files).
-  - Open the 'MarlinFirmware' project folder in Visual Studio Code.
-  - Click the "Auto Build Marlin" button and then the Upload button.
-  - Don't forget to reset your EEPROM with `M502` and `M500` after flashing.
+ - Linear advance is working but CPU can not handle high speed (more than 90 mm/s or even less)
+ - Because P905 has heavy X and even heavier Y mass you should consider lower jerk values compared to other printers
+ - Turning off linear advance/jerk could let you print faster but you should lower print acceleration to 200 (as it was in manufacturer config)
+ 
+There are some comments in the code that you can find by "P905H" keyword.

--- a/config/examples/FlyingBear/P905H/README.md
+++ b/config/examples/FlyingBear/P905H/README.md
@@ -2,10 +2,10 @@
 
 Configuration is based on P905H with **a single extruder and inductive Z-sensor**.
 
-I've tried to adapt original Marlin 1.x limits to Marlin 2.1.x with classical jerk and linear advance enabled.
+I've tried to adapt original Marlin 1.x limits to Marlin 2.1.x with classical Jerk and Linear Advance enabled.
 
- - Linear advance is working but CPU can not handle high speed (more than 90 mm/s or even less)
- - Because P905 has heavy X and even heavier Y mass you should consider lower jerk values compared to other printers
- - Turning off linear advance/jerk could let you print faster but you should lower print acceleration to 200 (as it was in manufacturer config)
+ - Linear Advance is working but CPU can not handle high speed (more than 90 mm/s or even less).
+ - Because P905H has heavy X and even heavier Y mass you should consider lower jerk values compared to other printers.
+ - Turning off linear advance/jerk may allow faster printing, but reduce print acceleration to 200 (as in factory config).
  
-There are some comments in the code that you can find by "P905H" keyword.
+Additional comments in the configurations are annotated with "P905H".


### PR DESCRIPTION
## Description

Took latest configuration files and ported P905H options there.

Tried to to make printer work faster while preserving decent quality.

## Benefits

Print speed could be up to 90mm/s with linear advance enabled.

## Related Issues

On higher speeds >= 90mm/s or similar linear advance makes printer periodically stuck - CPU is to slow for this fancy calculations. Turning linear advance K factor to 0 allows to print on 100mm/s and above.