### PR TITLE
[Configuration] Update Artillery Hornet acceleration limits to prevent extruder stalling and optimize motion

### DIFF
--- a/config/examples/Artillery/Hornet/Configuration.h
+++ b/config/examples/Artillery/Hornet/Configuration.h
@@ -1386,7 +1386,7 @@
  * Override with M201
  *                                      X, Y, Z [, I [, J [, K...]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_ACCELERATION      { 2000, 2000, 100, 10000 }
+#define DEFAULT_MAX_ACCELERATION      { 3000, 1500, 100, 5000 }
 
 //#define LIMITED_MAX_ACCEL_EDITING     // Limit edit via M201 or LCD to DEFAULT_MAX_ACCELERATION * 2
 #if ENABLED(LIMITED_MAX_ACCEL_EDITING)
@@ -1401,9 +1401,9 @@
  *   M204 R    Retract Acceleration
  *   M204 T    Travel Acceleration
  */
-#define DEFAULT_ACCELERATION           800    // X, Y, Z and E acceleration for printing moves
-#define DEFAULT_RETRACT_ACCELERATION 10000    // E acceleration for retracts
-#define DEFAULT_TRAVEL_ACCELERATION   2000    // X, Y, Z acceleration for travel (non printing) moves
+#define DEFAULT_ACCELERATION          3000    // X, Y, Z and E acceleration for printing moves
+#define DEFAULT_RETRACT_ACCELERATION  5000    // E acceleration for retracts
+#define DEFAULT_TRAVEL_ACCELERATION   3000    // X, Y, Z acceleration for travel (non printing) moves
 
 /**
  * Default Jerk limits (mm/s)


### PR DESCRIPTION
### Description

The current default configuration for the Artillery Hornet sets the maximum extruder acceleration (`DEFAULT_MAX_ACCELERATION` E) to an unrealistic value of `10000`. This causes systematic extruder motor stalling and step loss (clicking) during fast retractions, due to the physical friction inside the proprietary hybrid Bowden cable system.

Furthermore, the default travel and print accelerations were underutilizing the actual mechanical capabilities of the X axis, while the Y axis required a more conservative limit to handle the heavy heated bed mass (bedslinger geometry).

This PR tunes the acceleration and travel values based on extensive real-world testing, fixing the extruder issue and maximizing motion efficiency without introducing ghosting or layer shifts.

### Proposed Changes

The following values in `config/examples/Artillery/Hornet/Configuration.h` have been updated:

```cpp
#define DEFAULT_ACCELERATION          3000
#define DEFAULT_TRAVEL_ACCELERATION   3000
#define DEFAULT_MAX_ACCELERATION      { 3000, 1500, 100, 5000 }
#define DEFAULT_RETRACT_ACCELERATION  5000
```

#### Rationale:
- **`DEFAULT_ACCELERATION` & `DEFAULT_TRAVEL_ACCELERATION` (3000):** Raised to match the mechanical capabilities of the printer, significantly reducing print times safely.
- **`DEFAULT_MAX_ACCELERATION` X (3000) & Y (1500):** Decoupled and balanced. X can easily handle 3000 mm/s², while Y is capped at 1500 mm/s² to prevent layer shifts caused by the inertia of the glass bed.
- **`DEFAULT_MAX_ACCELERATION` E (5000) & `DEFAULT_RETRACT_ACCELERATION` (5000):** Halving the stock value (from 10000 to 5000) grants the extruder motor enough torque to overcome filament resistance, completely eliminating step loss/clicking during quick retractions while maintaining crisp filament control.

### Benefits

- **Reliability:** Fixes the historical extruder clicking issue inherent to stock Artillery Hornet profiles.
- **Print Quality:** Eliminates potential ghosting on the Y axis by reducing its maximum acceleration.
- **Performance:** Speeds up non-printing moves and standard printing moves on capable axes.

### Testing

- **Printer:** Artillery Hornet (Stock extruder, stock bed).
- **Firmware Feature:** **Input Shaping enabled and calibrated.**
- **Test Prints:** Multiple 3D Benchy models, calibration cubes, and resonance test towers.
- **Results:** Zero extruder clicks or step losses recorded. Thanks to Input Shaping, walls are perfectly smooth with zero ghosting or ringing at 3000 mm/s² acceleration.

### Checklist

- [x] I have tested these changes on real hardware.
- [x] Only the specific configuration files for the Artillery Hornet have been modified.