### PR TITLE
[Sovol][SV-06] Homing Bump of XY should be 0 because of sensorless probing

### DIFF
--- a/config/examples/Sovol/SV-06/Configuration_adv.h
+++ b/config/examples/Sovol/SV-06/Configuration_adv.h
@@ -962,7 +962,7 @@
 
 #define SENSORLESS_BACKOFF_MM  { 2, 2, 0 }    // (linear=mm, rotational=°) Backoff from endstops before sensorless homing
 
-#define HOMING_BUMP_MM      { 2, 2, 2 }       // (linear=mm, rotational=°) Backoff from endstops after first bump
+#define HOMING_BUMP_MM      { 0, 0, 2 }       // (linear=mm, rotational=°) Backoff from endstops after first bump
 #define HOMING_BUMP_DIVISOR { 2, 2, 4 }       // Re-Bump Speed Divisor (Divides the Homing Feedrate)
 
 //#define HOMING_BACKOFF_POST_MM { 2, 2, 2 }  // (linear=mm, rotational=°) Backoff from endstops after homing


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Because of sensorless probing, HOMING_BUMP_MM of X and Y axis should be 0 per documentation. I have found that my printer experience less grinding at the end-stop because of this as well.

### Benefits

Improve homing, reduces grinding

### Related Issues

-
