### PR TITLE
🩹 Drop Hurakan SDCARD_CONNECTION workaround

### DIFF
--- a/config/examples/BIQU/Hurakan/Configuration_adv.h
+++ b/config/examples/BIQU/Hurakan/Configuration_adv.h
@@ -2079,7 +2079,7 @@
    *
    * :[ 'LCD', 'ONBOARD', 'CUSTOM_CABLE' ]
    */
-  #define SDCARD_CONNECTION LCD // Required for LCD contrast to be initialized correctly. Onboard SD is inaccessible.
+  #define SDCARD_CONNECTION ONBOARD
 
   // Enable if SD detect is rendered useless (e.g., by using an SD extender)
   //#define NO_SD_DETECT


### PR DESCRIPTION
### Description

The Hurakan shipped with `SDCARD_CONNECTION LCD` as a workaround because the onboard SD was unusable and LCD contrast only initialized in that mode. MarlinFirmware/Marlin#28567 fixes both, and the LCD's SD slot isn't reachable on this printer, so point it at the onboard slot.

### Benefits

Hurakan users get the SD slot they can actually access.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/pull/28567